### PR TITLE
兼容官方及第三方的ChatGPT接口

### DIFF
--- a/LunaTranslator/LunaTranslator/translator/chatgpt-3rd-party.py
+++ b/LunaTranslator/LunaTranslator/translator/chatgpt-3rd-party.py
@@ -1,0 +1,64 @@
+from traceback import print_exc
+
+import json
+import requests
+
+from translator.basetranslator import basetrans
+import os
+
+
+class TS(basetrans):
+    def langmap(self):
+        return {"zh": "zh-CN", "cht": "zh-TW"}
+
+    def __init__(self, typename):
+        self.context = []
+        super().__init__(typename)
+
+    def inittranslator(self):
+        self.api_key = None
+
+    def translate(self, query):
+        os.environ['https_proxy'] = self.proxy['https'] if self.proxy['https'] else ''
+        os.environ['http_proxy'] = self.proxy['http'] if self.proxy['http'] else ''
+        self.checkempty(['SECRET_KEY', 'model'])
+        self.contextnum = int(self.config['附带上下文个数'])
+
+        try:
+            temperature = float(self.config['Temperature'])
+        except:
+            temperature = 0.3
+
+        message = [
+            {"role": "system", "content": "You are a translator"},
+            {"role": "user", "content": f"translate from {self.srclang} to {self.tgtlang}"},
+        ]
+
+        for _i in range(min(len(self.context) // 2, self.contextnum)):
+            i = len(self.context) // 2 - min(len(self.context) // 2, self.contextnum) + _i
+            message.append(self.context[i * 2])
+            message.append(self.context[i * 2 + 1])
+        message.append({"role": "user", "content": query})
+
+        headers = {
+            'Authorization': 'Bearer ' + self.config['SECRET_KEY'],
+            'Content-Type': 'application/json',
+        }
+
+        data = '{ "model": ' + json.dumps(
+            self.config['model']) + ', "stream": false, "temperature": ' + json.dumps(temperature) + ', "messages": ' + json.dumps(
+            message) + ' }'
+
+        response = requests.post(self.config['API接口地址'] + '/chat/completions', headers=headers, data=data)
+        response = response.json()
+
+        try:
+            message = response['choices'][0]['message']['content'].replace('\n\n', '\n').strip()
+            self.context.append({"role": "user", "content": query})
+            self.context.append({
+                'role': "assistant",
+                "content": message
+            })
+            return message
+        except:
+            raise Exception(json.dumps(response))

--- a/LunaTranslator/files/defaultconfig/config.json
+++ b/LunaTranslator/files/defaultconfig/config.json
@@ -843,6 +843,11 @@
           "color": "blue",
           "name": "ChatGPT"
         },
+		"chatgpt-3rd-party": {
+          "use": false,
+          "color": "blue",
+          "name": "ChatGPT(第三方接口)"
+        },
 		"hanshant": {
             "use": false,
             "color": "blue",

--- a/LunaTranslator/files/defaultconfig/translatorsetting.json
+++ b/LunaTranslator/files/defaultconfig/translatorsetting.json
@@ -179,6 +179,45 @@
 			}
 		}
     },
+	"chatgpt-3rd-party": {
+      "args": {
+		"注册地址": "https://platform.openai.com/account/api-keys",
+        "项目地址": "https://github.com/songquanpeng/one-api",
+		"使用说明": "直接调用chat/completions接口而不使用openaiSDK。\n可以使用官方的Key也可以使用one-api对多个ChatGPT账户进行聚合请求，避免出现限流。\n也兼容大多数第三方接口，接口地址请填写到/v1即可。",
+        "SECRET_KEY": "",
+        "Temperature": 0.3,
+		"model":"gpt-3.5-turbo",
+		"附带上下文个数":0,
+		"API接口地址":"https://api.openai.com/v1"
+      }
+	  ,
+		"argstype":{
+			"附带上下文个数":{
+				"type":"intspin",
+				"min":0,
+				"max":10,
+				"step":1
+			},
+			"注册地址":{
+				"type":"label",
+				"islink":true
+			},
+			"项目地址":{
+				"type":"label",
+				"islink":true
+			},
+			"使用说明":{
+				"type":"label",
+				"islink":false
+			},
+			"Temperature":{
+				"type":"spin",
+				"min":0,
+				"max":1,
+				"step":0.1
+			}
+		}
+    },
     "jb7": {
         "args": {
             "路径": "",


### PR DESCRIPTION
直接请求chat/completions而不使用openai-python以兼容[one-api](https://github.com/songquanpeng/one-api)和绝大多数第三方的ChatGPT API实现。
（第三方的API通常仅实现了chat/completions接口，使用openai-python库请求会报错）
解决如下issue
https://github.com/HIllya51/LunaTranslator/issues/278#issuecomment-1534501427
https://github.com/HIllya51/LunaTranslator/issues/266#issuecomment-1526211301
![QQ截图20230505151254](https://user-images.githubusercontent.com/1808555/236398097-81fb599a-1c29-4390-b678-85dc2ce1f0e3.png)
（使用了官方的接口）
![QQ截图20230505151217](https://user-images.githubusercontent.com/1808555/236398186-b932d82a-f8dd-45eb-a616-0606c55f7818.png)
（使用了第三方接口）
