### PR TITLE
重新翻译按钮不再要求文本差异，方便大模型翻译多次尝试

### DIFF
--- a/LunaTranslator/LunaTranslator/LunaTranslator.py
+++ b/LunaTranslator/LunaTranslator/LunaTranslator.py
@@ -142,7 +142,7 @@ class MAINUI() :
         ss=POSTSOLVE(s)
         self.settin_ui.showandsolvesig.emit(s)
         return ss
-    def textgetmethod(self,_paste_str,shortlongskip=True,embedcallback=None,onlytrans=False):
+    def textgetmethod(self,_paste_str,shortlongskip=True,embedcallback=None,onlytrans=False,forcetrans=False):
         _autolock(self.solvegottextlock)
         if onlytrans==False:
             self.currentsignature=time.time()
@@ -178,15 +178,15 @@ class MAINUI() :
         while len(_paste_str) and _paste_str[-1] in '\r\n \t':  #在后处理之后在去除换行，这样换行符可以当作行结束符给后处理用
             _paste_str=_paste_str[:-1]  
             
-        if _paste_str=='' or (shortlongskip and (_paste_str==self.currenttext or len(_paste_str)>1000)):
+        if _paste_str=='' or (shortlongskip and (_paste_str==self.currenttext and not forcetrans or len(_paste_str)>1000)):
             if embedcallback:
                 embedcallback('zhs', _paste_str) 
             return 
         
-        
-        try:
-            self.textsource.sqlqueueput((_paste_str,)) 
-        except:pass
+        if _paste_str != self.currenttext:
+            try:
+                self.textsource.sqlqueueput((_paste_str,)) 
+            except:pass
         if onlytrans==False:
             self.currenttext=_paste_str
             if globalconfig['outputtopasteboard'] and globalconfig['sourcestatus2']['copy']['use']==False:  
@@ -211,7 +211,6 @@ class MAINUI() :
         paste_str_solved,optimization_params= self.solvebeforetrans(_paste_str) 
         
         skip=shortlongskip and  (len(paste_str_solved)<globalconfig['minlength'] or len(paste_str_solved)>globalconfig['maxlength'] )
-
         self.premtalready=['premt']
         if 'premt' in self.translators:
             try:
@@ -228,10 +227,10 @@ class MAINUI() :
         _len=len(self.translators)
         keys=list(self.translators.keys())+list(self.translators.keys())
         keys=keys[self.lasttranslatorindex:self.lasttranslatorindex+_len]
-        #print(keys,usenum,self.lasttranslatorindex)
+        # print(keys,usenum,self.lasttranslatorindex)
         for engine in keys:  
             if engine not in self.premtalready:
-                self.translators[engine].gettask((partial(self.GetTranslationCallback,onlytrans,engine,self.currentsignature, optimization_params,_showrawfunction,_showrawfunction_sig,_paste_str),_paste_str,paste_str_solved,skip,embedcallback,shortlongskip,hira)) 
+                self.translators[engine].gettask((partial(self.GetTranslationCallback,onlytrans,engine,self.currentsignature, optimization_params,_showrawfunction,_showrawfunction_sig,_paste_str),_paste_str,paste_str_solved,skip,embedcallback,shortlongskip,hira,forcetrans)) 
             thistimeusednum+=1
             self.lasttranslatorindex+=1
             if(thistimeusednum>=usenum):
@@ -289,19 +288,7 @@ class MAINUI() :
             time.sleep(globalconfig['textthreaddelay']/1000)
             name=(self.textsource.currentname)
             names=savehook_new_data[self.textsource.pname]['allow_tts_auto_names'].split('|')
-            needpass=False
-            if name in names:
-                needpass=True
-            
-            #name文本是类似“美香「おはよう」”的形式
-            text=name
-            for _name in names:
-                if text.startswith(_name) or text.endswith(_name):
-                    if len(text)>=len(_name)+3:    #2个引号+至少1个文本内容。
-                        needpass=True
-                        break
-             
-            if needpass==False:# name not in names: 
+            if name not in names: 
                 self.readcurrent()
             gobject.baseobject.textsource.currentname=None
         except:

--- a/LunaTranslator/LunaTranslator/gui/translatorUI.py
+++ b/LunaTranslator/LunaTranslator/gui/translatorUI.py
@@ -237,7 +237,7 @@ class QUnFrameWindow(resizableframeless):
             gobject.baseobject.textgetmethod(text,False)
         functions=(
             ("move",None),
-            ("retrans",self.startTranslater),
+            ("retrans",self.reTranslater),
             ("automodebutton",self.changeTranslateMode),
             ("setting",lambda:gobject.baseobject.settin_ui.showsignal.emit()),
             ("copy",lambda:winsharedutils.clipboard_set( gobject.baseobject.currenttext)),
@@ -533,7 +533,11 @@ class QUnFrameWindow(resizableframeless):
     def startTranslater(self) :
         if gobject.baseobject.textsource :
             threading.Thread(target=gobject.baseobject.textsource.runonce).start()
-         
+
+    def reTranslater(self):
+        if gobject.baseobject.textsource :
+            threading.Thread(target=gobject.baseobject.textsource.runonce, args=('True',)).start()
+
     def toolbarhidedelay(self):
         
         for button in self.buttons:

--- a/LunaTranslator/LunaTranslator/textsource/copyboard.py
+++ b/LunaTranslator/LunaTranslator/textsource/copyboard.py
@@ -19,5 +19,5 @@ class copyboard(basetext):
                 if globalconfig['excule_from_self']   and win32utils.GetWindowThreadProcessId(win32utils.GetClipboardOwner())==os.getpid():
                     return  
                 return (paste_str)
-    def runonce(self): 
-        self.textgetmethod(winsharedutils.clipboard_get(),False)
+    def runonce(self, forcetrans=False): 
+        self.textgetmethod(winsharedutils.clipboard_get(),False, forcetrans=forcetrans)

--- a/LunaTranslator/LunaTranslator/textsource/ocrtext.py
+++ b/LunaTranslator/LunaTranslator/textsource/ocrtext.py
@@ -119,7 +119,7 @@ class ocrtext(basetext):
             
             return (text)
             
-    def runonce(self): 
+    def runonce(self, forcetrans=False): 
         
         if self.rect is None:
             return
@@ -134,7 +134,7 @@ class ocrtext(basetext):
         self.savelastrecimg=imgr1
         self.lastocrtime=time.time()
         self.savelasttext=text
-        self.textgetmethod(text,False)
+        self.textgetmethod(text,False, forcetrans=forcetrans)
     def ocrtest(self,img):
          
         fname='./cache/ocr/{}.png'.format(self.timestamp)

--- a/LunaTranslator/LunaTranslator/textsource/texthook.py
+++ b/LunaTranslator/LunaTranslator/textsource/texthook.py
@@ -313,9 +313,9 @@ class texthook(basetext  ):
             while self.newline.empty()==False:
                 paste_str=self.newline.get()  
             return paste_str
-    def runonce(self):
+    def runonce(self, forcetrans=False):
          
-        self.textgetmethod(self.runonce_line,False)
+        self.textgetmethod(self.runonce_line,False, forcetrans=forcetrans)
     def end(self):    
         for pid in self.pids:
             self.RPC.Detach(pid)

--- a/LunaTranslator/LunaTranslator/textsource/textsourcebase.py
+++ b/LunaTranslator/LunaTranslator/textsource/textsourcebase.py
@@ -94,7 +94,7 @@ class basetext:
             
     def gettextthread(self):
         pass
-    def runonce(self):
+    def runonce(self, forcetrans=False):
         pass
     def end(self):
         self.ending=True

--- a/LunaTranslator/LunaTranslator/translator/basetranslator.py
+++ b/LunaTranslator/LunaTranslator/translator/basetranslator.py
@@ -198,11 +198,12 @@ class basetrans:
         if langkey not in self._cache:
             self._cache[langkey]={}
         self._cache[langkey][src] = tgt
-    def cached_translate(self,contentsolved,hira):
-
-        res=self.shorttermcacheget(contentsolved)
-        if res:
-            return res
+    def cached_translate(self,contentsolved,hira,forcetrans):
+        
+        if not forcetrans:
+            res=self.shorttermcacheget(contentsolved)
+            if res:
+                return res
         if globalconfig['uselongtermcache']:
             res=self.longtermcacheget(contentsolved)
             if res:
@@ -219,11 +220,11 @@ class basetrans:
         
         return res
     
-    def maybecachetranslate(self,contentraw,contentsolved,hira):
+    def maybecachetranslate(self,contentraw,contentsolved,hira,forcetrans):
         if self.transtype=='pre':
             res=self.translate(contentraw)
         else: 
-            res=self.cached_translate(contentsolved,hira)
+            res=self.cached_translate(contentsolved,hira,forcetrans)
         return res
     def intervaledtranslate(self,content,hira):
         interval=globalconfig['requestinterval']
@@ -260,7 +261,7 @@ class basetrans:
             savelast=[]
             while True:
                 _=self.queue.get() 
-                callback,contentraw,contentsolved,skip,embedcallback,shortlongskip,hira=_
+                callback,contentraw,contentsolved,skip,embedcallback,shortlongskip,hira,forcetrans=_
                 if embedcallback is not None:
                     savelast.clear()
                 
@@ -268,7 +269,7 @@ class basetrans:
                 if self.queue.empty():
                     break
             if savelast[0][4] is not None:
-                callback,contentraw,contentsolved,skip,embedcallback,shortlongskip,hira=savelast.pop(0)
+                callback,contentraw,contentsolved,skip,embedcallback,shortlongskip,hira,forcetrans=savelast.pop(0)
                 for _ in savelast:
                     self.gettask(_)
             if embedcallback is None:
@@ -285,7 +286,7 @@ class basetrans:
                         if self.needreinit:
                             self.needreinit=False
                             self.inittranslator()
-                        return self.maybecachetranslate(contentraw,contentsolved,hira)
+                        return self.maybecachetranslate(contentraw,contentsolved,hira,forcetrans)
                     res=timeoutfunction(reinitandtrans,checktutukufunction=checktutukufunction ) 
                     if self.needzhconv:
                         res=zhconv.convert(res,  'zh-tw' )  


### PR DESCRIPTION
issue里有个关闭的类似问题 #288 ，看意思似乎是让我手动修改文本使缓存失效，但实际挺麻烦的，因为我在用luna hooktext测本地模型的翻译效果，需要经常重新翻译，希望能让重新翻译能真的重新翻译（我猜测原本的重新翻译那么设计是让ocr重新识别？所以我这么改不知道合不合适）