### PR TITLE
Fix not valid win32 application in python3.7

### DIFF
--- a/LunaTranslator/LunaTranslator/translator/ort_sp.py
+++ b/LunaTranslator/LunaTranslator/translator/ort_sp.py
@@ -60,6 +60,7 @@ class TS(basetrans):
         return
     
     def setup_ortmtlib(self, ort_dll_path, model_path):
+        self.ort = ctypes.CDLL(os.path.join(os.path.dirname(ort_dll_path), "onnxruntime.dll"))
         self.ortmtlib = ctypes.CDLL(ort_dll_path)
 
         self.ortmtlib.create_ort_session.restype = ctypes.c_int


### PR DESCRIPTION
If don't load onnxruntime dll first, `%1 is not a valid win32 application` error will show up when loading `ortmtlib.dll` in python3.7.