### PR TITLE
新增OCR：manga-ocr

### DIFF
--- a/LunaTranslator/LunaTranslator/ocrengines/mangaocr.py
+++ b/LunaTranslator/LunaTranslator/ocrengines/mangaocr.py
@@ -9,7 +9,7 @@ class OCR(baseocr):
         self.checkempty(['api_url'])
         api_url=self.config['api_url']
         
-        response = requests.get(api_url, json={'image_path': os.path.abspath(img_path)})
+        response = requests.get(f'{api_url}?image_path={os.path.abspath(img_path)}')
 
         try:
             return response.json()['text']

--- a/LunaTranslator/LunaTranslator/ocrengines/mangaocr.py
+++ b/LunaTranslator/LunaTranslator/ocrengines/mangaocr.py
@@ -6,12 +6,15 @@ class OCR(baseocr):
     
     def ocr(self, img_path):
         
-        self.checkempty(['api_url'])
-        api_url=self.config['api_url']
+        self.checkempty(['Port'])
+        self.port = self.config['Port']
+
+        absolute_img_path = os.path.abspath(img_path)
+        params = {'image_path': absolute_img_path}
         
-        response = requests.get(f'{api_url}?image_path={os.path.abspath(img_path)}')
+        response = requests.get(f'http://127.0.0.1:{self.port}/image', params=params)
 
         try:
             return response.json()['text']
-        except:
-            raise Exception(response.text)
+        except Exception as e:
+            raise Exception(response.text) from e

--- a/LunaTranslator/LunaTranslator/ocrengines/mangaocr.py
+++ b/LunaTranslator/LunaTranslator/ocrengines/mangaocr.py
@@ -1,0 +1,17 @@
+import requests
+from ocrengines.baseocrclass import baseocr
+import os
+
+class OCR(baseocr):
+    
+    def ocr(self, img_path):
+        
+        self.checkempty(['api_url'])
+        api_url=self.config['api_url']
+        
+        response = requests.get(api_url, json={'image_path': os.path.abspath(img_path)})
+
+        try:
+            return response.json()['text']
+        except:
+            raise Exception(response.text)

--- a/LunaTranslator/files/defaultconfig/config.json
+++ b/LunaTranslator/files/defaultconfig/config.json
@@ -757,7 +757,7 @@
         },
         "mangaocr": {
             "use": false,
-            "name": "mangaOCR"
+            "name": "manga-ocr"
         }
     },
     "fanyi": {

--- a/LunaTranslator/files/defaultconfig/config.json
+++ b/LunaTranslator/files/defaultconfig/config.json
@@ -754,6 +754,10 @@
         "volcengine": {
             "use": false,
             "name": "火山OCR"
+        },
+        "mangaocr": {
+            "use": false,
+            "name": "mangaOCR"
         }
     },
     "fanyi": {

--- a/LunaTranslator/files/defaultconfig/ocrsetting.json
+++ b/LunaTranslator/files/defaultconfig/ocrsetting.json
@@ -170,7 +170,7 @@
         "args": {
             "项目仓库": "https://github.com/kha-white/manga-ocr",
             "整合包": "https://github.com/raindrop213/LunaTranslator-re/releases/download/v0.0.2/manga-ocr_v0.1.11.zip",
-            "api_url": "http://127.0.0.1:5665/image"
+            "Port":5665
         },
         "argstype": {
             "项目仓库": {
@@ -180,7 +180,13 @@
             "整合包": {
                 "type": "label",
                 "islink": true
-            }
+            },
+            "Port":{
+				"type":"intspin",
+				"min":1,
+				"max":65535,
+				"step":1
+			}
         }
     }
 }

--- a/LunaTranslator/files/defaultconfig/ocrsetting.json
+++ b/LunaTranslator/files/defaultconfig/ocrsetting.json
@@ -169,7 +169,7 @@
     "mangaocr": {
         "args": {
             "项目仓库": "https://github.com/kha-white/manga-ocr",
-            "整合包": "https://github.com/raindrop213/LunaTranslator-re/releases/download/v0.0.2/manga-ocr_v0.1.11_CPU.zip",
+            "整合包": "https://github.com/raindrop213/LunaTranslator-re/releases/download/v0.0.2/manga-ocr_v0.1.11.zip",
             "api_url": "http://127.0.0.1:5665/image"
         },
         "argstype": {

--- a/LunaTranslator/files/defaultconfig/ocrsetting.json
+++ b/LunaTranslator/files/defaultconfig/ocrsetting.json
@@ -165,5 +165,22 @@
                 "list_function":["ocrengines.tesseract5","list_langs"]
             }
 		}
+    },
+    "mangaocr": {
+        "args": {
+            "项目仓库": "https://github.com/kha-white/manga-ocr",
+            "整合包": "https://github.com/raindrop213/LunaTranslator-re/releases/download/v0.0.2/manga-ocr_v0.1.11_CPU.zip",
+            "api_url": "http://127.0.0.1:5665/image"
+        },
+        "argstype": {
+            "项目仓库": {
+                "type": "label",
+                "islink": true
+            },
+            "整合包": {
+                "type": "label",
+                "islink": true
+            }
+        }
     }
 }


### PR DESCRIPTION
OCR项目来自：[manga-ocr](https://github.com/kha-white/manga-ocr)
漫画特化的OCR模型，日文识别效果特别好，尤其是在纵向日文方面比有道要好

[整合包](https://github.com/raindrop213/LunaTranslator-re/releases/download/v0.0.2/manga-ocr_v0.1.11_CPU.zip)
原项目基础上的修改：api.py（简单加了个flask）
使用：打开start.bat

![image](https://github.com/HIllya51/LunaTranslator/assets/53202747/ecf965df-9544-4b1f-87e6-289657930e86)
默认是CPU，速度已经很快了，考虑到文件大小先这样了
链接名字不太会改，如果作者有意采纳的话可以商量一下整合包放哪，谢谢！

![test](https://github.com/HIllya51/LunaTranslator/assets/53202747/303ac07e-361f-474c-bc29-5e0ab89c65e0)
一般都不会扫到振假名