### PR TITLE
window geometry: check x, y values

### DIFF
--- a/LunaTranslator/LunaTranslator/gui/usefulwidget.py
+++ b/LunaTranslator/LunaTranslator/gui/usefulwidget.py
@@ -94,6 +94,8 @@ class saveposwindow(QMainWindow):
         d = QApplication.primaryScreen()
         self.dic, self.key = dic, key
         if self.dic:
+            dic[key][2] = min(dic[key][2], d.size().width())
+            dic[key][3] = min(dic[key][3], d.size().height())
             dic[key][0] = min(max(dic[key][0], 0), d.size().width() - dic[key][2])
             dic[key][1] = min(max(dic[key][1], 0), d.size().height() - dic[key][3])
             self.setGeometry(*dic[key])

--- a/LunaTranslator/LunaTranslator/gui/usefulwidget.py
+++ b/LunaTranslator/LunaTranslator/gui/usefulwidget.py
@@ -94,8 +94,8 @@ class saveposwindow(QMainWindow):
         d = QApplication.primaryScreen()
         self.dic, self.key = dic, key
         if self.dic:
-            dic[key][2] = min(dic[key][2], d.size().width())
-            dic[key][3] = min(dic[key][3], d.size().height())
+            dic[key][2] = max(0, min(dic[key][2], d.size().width()))
+            dic[key][3] = max(0, min(dic[key][3], d.size().height()))
             dic[key][0] = min(max(dic[key][0], 0), d.size().width() - dic[key][2])
             dic[key][1] = min(max(dic[key][1], 0), d.size().height() - dic[key][3])
             self.setGeometry(*dic[key])


### PR DESCRIPTION
部分游戏切换全屏状态会改变 luna translator 的窗口位置, 保存到配置文件时 geo 数值可能会出现抽象的情况. 在我的设备上:

```
"transuigeo": [
        -14903,
        539,
        21845,
        101
    ],
```

负值导致下次启动失败.