### PR TITLE
Removed .lower() that messed up the hash

### DIFF
--- a/LunaTranslator/LunaTranslator/textoutput/websocket.py
+++ b/LunaTranslator/LunaTranslator/textoutput/websocket.py
@@ -44,7 +44,7 @@ class websocketserver:
                 key = line.split(":")[1].strip()
                 break
         value = f"{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11".encode("utf-8")
-        hashed = base64encode(hashlib.sha1(value).digest()).strip().lower().decode()
+        hashed = base64encode(hashlib.sha1(value).digest()).strip().decode()
         # 构造握手响应
         response = "HTTP/1.1 101 Switching Protocols\r\n"
         response += "Upgrade: websocket\r\n"


### PR DESCRIPTION
This PR is a simple fix that removes `.lower()`.

When I tried to `wscat -c ws://127.0.0.1:2233` to my websocket, I got the `error: Invalid Sec-WebSocket-Accept header`.

Looking into the code, I saw that `Sec-WebSocket-Accept header` is Base64 encoded, which is case sensitive. However, there is a `.lower()` converts the whole Base64 string to lowercase, turning it an entirely new hash, thus resulting in the error.
