### PR TITLE
fix ort_sp repeating by spliting long text to sentences

### DIFF
--- a/LunaTranslator/LunaTranslator/translator/ort_sp.py
+++ b/LunaTranslator/LunaTranslator/translator/ort_sp.py
@@ -3,6 +3,7 @@ import ctypes
 import os
 import glob
 import platform
+import re
 
 
 class TS(basetrans):
@@ -255,9 +256,21 @@ class TS(basetrans):
         return output_ids_py
 
     def translate(self, content):
-        input_ids_py = self.encode_as_ids(content)
-        output_ids_py = self.run_session(input_ids_py)
-        translated = self.decode_from_ids(output_ids_py)
+        delimiters = ['.','。','\n',':','：','?','？','!','！','……','「','」']
+        content_split = [i for i in re.split('(['+''.join(delimiters)+'])', content) if i]
+        translated_list = []
+        i = 0
+        while i < len(content_split):
+            sentence = content_split[i]
+            if i+1 < len(content_split):
+                i += 1
+                sentence += content_split[i]
+            input_ids_py = self.encode_as_ids(sentence)
+            output_ids_py = self.run_session(input_ids_py)
+            translated_sentence = self.decode_from_ids(output_ids_py)
+            translated_list.append(translated_sentence)
+            i += 1
+        translated = ''.join(translated_list)
         return translated
 
     def __del__(self):


### PR DESCRIPTION
Previously mt5 would repeat infinitely when translating text with repeating patterns, this could be mitigated by spliting original text to short sentences and translate them separately.