### PR TITLE
Remove subprotocol 111

### DIFF
--- a/LunaTranslator/LunaTranslator/textoutput/websocket.py
+++ b/LunaTranslator/LunaTranslator/textoutput/websocket.py
@@ -49,7 +49,6 @@ class websocketserver:
         response = "HTTP/1.1 101 Switching Protocols\r\n"
         response += "Upgrade: websocket\r\n"
         response += "Connection: Upgrade\r\n"
-        response += "sec-websocket-protocol: 111\r\n"
         response += f"Sec-WebSocket-Accept: {hashed}\r\n\r\n"
 
         # 发送握手响应给客户端


### PR DESCRIPTION
开发者您好，这里的 `sec-websocket-protocol: 111` 似乎是一个测试值，或者至少不是一个常见的subprotocol。将它移除能增强这个功能的兼容性，比如说能使用 https://github.com/Renji-XD/texthooker-ui [或者其他工具](https://arbyste.github.io/jp-mining-note-prerelease/setuptextmedia/#texthooker-websocket-based)来获取LunaTexthooker的输出。感谢您提供这么好用的工具！

This subprotocol seem to be a test string. Typical usage for websocket does not requires or does not support specifying subprotocol. For example, one popular websocket-based textractor websocket listener, https://github.com/Renji-XD/texthooker-ui,  assumes no subprotocol. Removing this header helps LunaTranslator connect with other tools in language learning communities. Thank you very much for this highly useful tool.
