### PR TITLE
Fix: improve winxp default ui font config

### DIFF
--- a/py/files/defaultconfig/static_data.json
+++ b/py/files/defaultconfig/static_data.json
@@ -313,8 +313,6 @@
             "Microsoft YaHei UI",
             "微软雅黑",
             "Microsoft YaHei",
-            "黑体",
-            "SimHei",
             "新宋体",
             "NSimSun",
             "宋体",


### PR DESCRIPTION
在 WinXP 中，黑体（SimHei）在小字、作为 UI 字体的渲染不佳。
因此删除默认 UI 字体中的“黑体”（SimHei）一项，
使在 WinXP 中的简体默认 UI 字体变为“新宋体”（NSimSun）。