### PR TITLE
fix: OCR selection issue on multi-monitor setup

### DIFF
--- a/py/LunaTranslator/gui/rangeselect.py
+++ b/py/LunaTranslator/gui/rangeselect.py
@@ -183,13 +183,14 @@ class rangeselect(QMainWindow):
         self.reset()
 
     def reset(self):
-        winsharedutils.maximum_window(int(self.winId()))
-        self.once = True
         self.is_drawing = False
-        self.start_point = QPoint()
-        self.end_point = QPoint()
         self.__start = None
         self.__end = None
+        self.start_point = None
+        self.end_point = None
+        self._cached_dpi = None
+        winsharedutils.maximum_window(int(self.winId()))
+        self.once = True
         self.startauto = False
         self.rectlabel.resize(0, 0)
         self.rectlabel.setStyleSheet(
@@ -286,12 +287,14 @@ screen_shot_ui = None
 
 def rangeselct_function(callback, startauto):
     global screen_shot_ui
-    if screen_shot_ui is None:
-        screen_shot_ui = rangeselect()
-        # 可能是由于使用win32移动窗口，导致父翻译show/hide影响到他
+    if screen_shot_ui is not None:
+        # 完全销毁旧的实例
+        screen_shot_ui.deleteLater()
+        screen_shot_ui = None
+    
+    screen_shot_ui = rangeselect()
     screen_shot_ui.show()
     screen_shot_ui.reset()
     screen_shot_ui.callback = callback
     windows.SetFocus(int(screen_shot_ui.winId()))
-
     screen_shot_ui.startauto = startauto

--- a/py/LunaTranslator/gui/rangeselect.py
+++ b/py/LunaTranslator/gui/rangeselect.py
@@ -183,14 +183,13 @@ class rangeselect(QMainWindow):
         self.reset()
 
     def reset(self):
-        self.is_drawing = False
-        self.__start = None
-        self.__end = None
-        self.start_point = None
-        self.end_point = None
-        self._cached_dpi = None
         winsharedutils.maximum_window(int(self.winId()))
         self.once = True
+        self.is_drawing = False
+        self.start_point = QPoint()
+        self.end_point = QPoint()
+        self.__start = None
+        self.__end = None
         self.startauto = False
         self.rectlabel.resize(0, 0)
         self.rectlabel.setStyleSheet(


### PR DESCRIPTION
## 问题描述
在多显示器环境下,创建新的OCR选择框时,如果存在旧的实例没有被正确销毁,可能会导致界面显示异常。具体表现为第一次OCR后后续OCR屏幕只有部分内容可被选中。

## 修改内容
在 `rangeselct_function` 中添加了实例销毁的逻辑，如果存在旧的实例就销毁它并重置全局变量然后再创建新实例。此修改在反复调用进行一次OCR功能测试解决原问题。