### PR TITLE
调高设置中大模型参数 temperature 的上限为 2.

### DIFF
--- a/py/files/defaultconfig/translatorsetting.json
+++ b/py/files/defaultconfig/translatorsetting.json
@@ -474,8 +474,8 @@
 			},
 			"Temperature": {
 				"type": "spin",
-				"min": 0,
-				"max": 1,
+				"min": -2,
+				"max": 2,
 				"step": 0.1
 			}
 		}
@@ -583,8 +583,8 @@
 			},
 			"Temperature": {
 				"type": "spin",
-				"min": 0,
-				"max": 1,
+				"min": -2,
+				"max": 2,
 				"step": 0.1
 			}
 		}
@@ -660,8 +660,8 @@
 			},
 			"Temperature": {
 				"type": "spin",
-				"min": 0,
-				"max": 1,
+				"min": -2,
+				"max": 2,
 				"step": 0.1
 			}
 		}
@@ -946,8 +946,8 @@
 			},
 			"Temperature": {
 				"type": "spin",
-				"min": 0,
-				"max": 1,
+				"min": -2,
+				"max": 2,
 				"step": 0.1
 			}
 		}
@@ -1001,7 +1001,7 @@
 			},
 			"temperature": {
 				"type": "spin",
-				"min": 0,
+				"min": -2,
 				"max": 2,
 				"step": 0.1
 			},
@@ -1146,8 +1146,8 @@
 			},
 			"Temperature": {
 				"type": "spin",
-				"min": 0,
-				"max": 1,
+				"min": -2,
+				"max": 2,
 				"step": 0.1
 			}
 		}


### PR DESCRIPTION
temperature 用来控制生成的回复的随机性，目前不同的大模型支持的参数范围不同，例如我在尝试使用 DeepSeek 模型进行翻译时，官方文档建议的 temperature 参考设置如下：

![image](https://github.com/user-attachments/assets/c5e28470-554c-4cd5-b052-c813750da183)

此 PR 用以调高设置中大模型参数 temperature 的上限为 2.