### PR TITLE
Do not append search word when searching words through clicks in the UI

### DIFF
--- a/src/LunaTranslator/LunaTranslator.py
+++ b/src/LunaTranslator/LunaTranslator.py
@@ -1026,7 +1026,7 @@ class MAINUI:
                 (winsharedutils.clipboard_get() + word) if append else word
             )
         if globalconfig["usesearchword"]:
-            self.searchwordW.search_word.emit(word, append)
+            self.searchwordW.search_word.emit(word, False)
 
     def __dontshowintaborsetbackdrop(self, widget: QWidget):
         window_flags = widget.windowFlags()


### PR DESCRIPTION
When searching words by mouse clicking, the words input are appended, this might not be the desired behavior here.

![image](https://github.com/user-attachments/assets/0f02130e-1e91-4f14-8f66-55148797a61e)
