### PR TITLE
修正文本预处理中过滤换行符功能的问题

### DIFF
--- a/src/LunaTranslator/myutils/post.py
+++ b/src/LunaTranslator/myutils/post.py
@@ -201,12 +201,12 @@ def _6_fEX(line: str):
     white = getlangsrc().space
     while True:
         curr = line
-        for _ in "\r\n\u2928\u2029":
+        for _ in "\r\n\u2028\u2029":
             line = line.replace(_ + " ", " ").replace(" " + _, " ")
         if line == curr:
             break
 
-    line = re.sub(r"[\r\n\u2928\u2029]+", white, line)
+    line = re.sub(r"[\r\n\u2028\u2029]+", white, line)
 
     return line
 

--- a/src/LunaTranslator/myutils/post.py
+++ b/src/LunaTranslator/myutils/post.py
@@ -199,15 +199,8 @@ def _4_f(line):
 
 def _6_fEX(line: str):
     white = getlangsrc().space
-    while True:
-        curr = line
-        for _ in "\r\n\u2028\u2029":
-            line = line.replace(_ + " ", " ").replace(" " + _, " ")
-        if line == curr:
-            break
-
-    line = re.sub(r"[\r\n\u2028\u2029]+", white, line)
-
+    sections = [sec.strip() for sec in line.splitlines()]
+    line = white.join(sec for sec in sections if sec)
     return line
 
 

--- a/src/LunaTranslator/myutils/post.py
+++ b/src/LunaTranslator/myutils/post.py
@@ -199,8 +199,7 @@ def _4_f(line):
 
 def _6_fEX(line: str):
     white = getlangsrc().space
-    sections = [sec.strip() for sec in line.splitlines()]
-    line = white.join(sec for sec in sections if sec)
+    line = white.join(sec for sec in line.splitlines() if sec)
     return line
 
 


### PR DESCRIPTION
过滤换行符功能对应函数中的Unicode字符错误，应为`\u2028`而不是`\u2928`
新实现中改为用python内置的字符串处理方法实现，python内置方法本身支持处理Unicode中的`\u2028 \u2029`，不必额外实现