### PR TITLE
Update hint for automatic clipboard output in docs

### DIFF
--- a/docs/en/alltoolbuttons.md
+++ b/docs/en/alltoolbuttons.md
@@ -136,7 +136,7 @@ Some buttons have two icons to indicate two different states. Some buttons only 
   
     This reading will ignore `Skip` (if in `Voice Settings`, the current text target is matched as `Skip`, then using the button for reading will ignore the skip and force the reading).
 1. #### <i class="fa fa-copy"></i> <i class="fa fa-icon fa-rotate-right"></i> Copy to Clipboard
-    Copy the currently extracted text to the clipboard once. If you want to automatically extract to the clipboard, enable `Text Input` → `Clipboard` → `Auto Output` → `Auto Output Text`.
+    Copy the currently extracted text to the clipboard once. If you want to automatically extract to the clipboard, enable `Core Settings` → `Clipboard` → `Output` → `Auto Output Text` and underneath it `Content` → `Original Text`.
 1. #### <i class="fa fa-rotate-left"></i> <i class="fa fa-icon fa-rotate-right"></i> Show/Hide History Text  
     Open or close the history text window.
 1. #### <i class="fa fa-gamepad"></i> <i class="fa fa-icon fa-rotate-right"></i> Game Management

--- a/docs/en/fastkeys.md
+++ b/docs/en/fastkeys.md
@@ -91,7 +91,7 @@
     The actual meaning is that regardless of the current default text input source, it reads text once from the clipboard and passes it to the subsequent translation/TTS/... process.
 
 1. #### Copy to Clipboard
-    Copies the currently extracted text to the clipboard once. If you want to automatically extract to the clipboard, enable `Text Input` → `Clipboard` → `Auto Output` → `Auto Output Text`.
+    Copies the currently extracted text to the clipboard once. If you want to automatically extract to the clipboard, enable `Core Settings` → `Clipboard` → `Output` → `Auto Output Text` and underneath it `Content` → `Original Text`.
 
 1. #### Copy Translation to Clipboard
     Copies the translation instead of the original text to the clipboard.


### PR DESCRIPTION
Took me some time to figure this out, mostly due to another issue but still.

![image(2)](https://github.com/user-attachments/assets/607581fa-1e24-4016-ab7e-5a5742487c6f)
