### PR TITLE
fix: 修复代理开关前端 UI 默认状态与后端不同步的 Bug

### DIFF
--- a/src/LunaTranslator/gui/setting/textinput.py
+++ b/src/LunaTranslator/gui/setting/textinput.py
@@ -582,7 +582,9 @@ def proxyusage():
     hbox.setContentsMargins(0, 0, 0, 0)
     w2 = QWidget()
     w2.setEnabled(globalconfig["useproxy"])
-    switch1 = D_getsimpleswitch(globalconfig, "useproxy", callback=w2.setEnabled)()
+    switch1 = D_getsimpleswitch(
+        globalconfig, "useproxy", callback=w2.setEnabled, default=True
+    )()
     hbox.addWidget(switch1)
     hbox.addWidget(QLabel())
     hbox.addWidget(w2)
@@ -597,7 +599,7 @@ def proxyusage():
         getboxlayout(
             [
                 "使用系统代理",
-                D_getsimpleswitch(globalconfig, "usesysproxy", callback=__)(),
+                D_getsimpleswitch(globalconfig, "usesysproxy", callback=__, default=True)(),
                 0,
             ]
         ),


### PR DESCRIPTION
注意到后端发送请求时的代码是`if pair is None or globalconfig[pair[0]][pair[1]].get("useproxy", True)`
`defaultconfig/config.json`里面也包含着 `"useproxy": true`
但在前端显示的时候默认是false，所以修改了前端的默认值，让前后端保持统一