### PR TITLE
修复带有自定义端口号的请求 URL 会被意外截断的 Bug

### DIFF
--- a/src/LunaTranslator/requests.py
+++ b/src/LunaTranslator/requests.py
@@ -247,6 +247,7 @@ class _Functions:
             raise exceptions.RequestException(
                 "unknown scheme {} for invalid url {}".format(scheme, url)
             )
+        original_host = server
         spl = server.split(":")
         if len(spl) == 2:
             server = spl[0]
@@ -268,8 +269,9 @@ class _Functions:
             path += "?" + query
         if frag:
             path += "#" + frag
-        url = scheme + "://" + server + path
+        url = scheme + "://" + original_host + path
         return scheme, server, port, path, url
+
 
     @staticmethod
     def _parsejson(_json):


### PR DESCRIPTION
**问题描述**
在 [requests.py](cci:7://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/requests.py:0:0-0:0) 执行底层的 [_parseurl](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/requests.py:240:4-272:46) 解析与重组代码时，提取端口所用的 `server.split(":")` 操作切改了原本的 [server](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/gui/setting/translate.py:914:0-963:14) 变量，但在最后一段组装目标 [url](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/requests.py:240:4-272:46) 时，却直接使用了这个被削减掉端口部分的 [server](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/gui/setting/translate.py:914:0-963:14)。
这导致部分诸如 `http://127.0.0.1:3000` 等非 `80/443` 标准端口的自建大模型（或其它三方服务）接口请求，末尾的端口号遭到丢失，直接触发连接被拒绝的网络异常。

**修改内容**
在执行 [split](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/gui/setting/translate.py:85:0-94:40) 分离端口号前，增加 `original_host = server` 暂存最初带有的完整 hostname 和 port。并在语句最末段重拼接 [url](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/requests.py:240:4-272:46) 时，将 [server](cci:1://file:///e:/AI%E5%AE%9E%E6%97%B6%E6%B1%89%E5%8C%96Galgame%E8%B5%84%E6%96%99/git/LunaTranslator/src/LunaTranslator/gui/setting/translate.py:914:0-963:14) 变量替换回 `original_host`。该小改动确保了最终的 URL 请求不仅能正确获取和剥离 port，也能够依然保持原有的完整路由格式。
