### PR TITLE
优化界面加载体验：为各翻译引擎添加"翻译中..."独立占位提示

### DIFF
--- a/src/LunaTranslator/LunaTranslator.py
+++ b/src/LunaTranslator/LunaTranslator.py
@@ -620,7 +620,7 @@ class BASEOBJECT(QObject):
                 return
 
         usefultranslators = real_fix_rank.copy()
-        if globalconfig["fix_translate_rank"] and (not waitforresultcallback):
+        if not waitforresultcallback:
             _showrawfunction = functools.partial(
                 self._delaypreparefixrank, _showrawfunction, real_fix_rank, is_auto_run
             )
@@ -666,9 +666,9 @@ class BASEOBJECT(QObject):
             if engine not in globalconfig["fanyi"]:
                 engine = "premt"
             displayreskwargs = dict(
-                name="",
+                name=_TR(dynamicapiname(engine)),
                 color=TranslateColor(engine),
-                res="",
+                res=_TR("翻译中..."),
                 iter_context=(1, engine),
                 klass=engine,
                 is_auto_run=is_auto_run,


### PR DESCRIPTION
在发送请求之后 首个token返回之前，显示"翻译中.."占位提示，优化网络延迟期间的用户体验；
解除了该占位符对"固定翻译引擎输出顺序"开关的依赖，默认触发显示。
<img width="814" height="143" alt="image" src="https://github.com/user-attachments/assets/37de4c1c-7f6e-4976-929a-3c6b43dcc7a7" />