### PR TITLE
feat: 按当前窗口标题动态生成截图保存目录 

### DIFF
--- a/src/LunaTranslator/gui/setting/display_scale.py
+++ b/src/LunaTranslator/gui/setting/display_scale.py
@@ -62,10 +62,37 @@ def createadaptercombo():
     return combo
 
 
+import os
+import re
+# 确保你已经从 qtsymbols 中导入了 QApplication (通常星号导入已经包含)
+# 如果没有包含，可以加上: from qtsymbols import QApplication
+
 def __getsavedir():
-    screenshotsDir = magpie_config["overlay"]["screenshotsDir"]
+    screenshotsDir = magpie_config["overlay"].get("screenshotsDir", "")
     if not screenshotsDir:
-        return os.path.expanduser("~/Pictures/Screenshots")
+        # 1. 尝试获取当前程序的实例
+        app = QApplication.instance()
+        title = "Magpie_Screenshots"  # 默认备用名称
+        
+        if app:
+            # 尝试获取当前活动窗口
+            active_window = app.activeWindow()
+            if active_window and active_window.windowTitle():
+                # 读取当前程序的窗口标题
+                title = active_window.windowTitle()
+            elif app.applicationName():
+                # 如果没有活动窗口，尝试获取程序名称
+                title = app.applicationName()
+                
+        # 2. 清理标题中的非法路径字符 (防止标题中有 / \ : * ? " < > | 等字符导致无法创建文件夹)
+        safe_title = re.sub(r'[\\/*?:"<>|]', "_", title).strip()
+        if not safe_title:
+            safe_title = "Screenshots"
+            
+        # 3. 组装最终的路径，例如：C:/Users/用户名/Pictures/Screenshots/程序标题
+        base_dir = os.path.expanduser("~/Pictures/Screenshots")
+        return os.path.join(base_dir, safe_title)
+        
     return screenshotsDir
 
 


### PR DESCRIPTION
目前程序的默认截图均保存在同一层级目录下（如 ~/Pictures/Screenshots），当截图较多时，不同来源的图片混杂在一起，难以分类和查找。
此 PR 改进了默认截图路径的生成逻辑：当用户未自定义截图路径时，系统会自动获取当前活动窗口的标题（或程序名称），将其作为子目录拼接在基础截图路径之后，从而实现按程序/窗口自动分类存储截图的功能。