### PR TITLE
fix: pause OCR updates when the history text view is focused

### DIFF
--- a/src/LunaTranslator/gui/transhist.py
+++ b/src/LunaTranslator/gui/transhist.py
@@ -637,6 +637,15 @@ class transhist(closeashidewindow):
     def showEvent(self, e):
         super().showEvent(e)
         self.__load()
+        from textio.textsource.ocrtext import ocrtext
+        if isinstance(gobject.base.textsource, ocrtext):
+            gobject.base.textsource.pause_recognition()
+
+    def hideEvent(self, e):
+        from textio.textsource.ocrtext import ocrtext
+        if isinstance(gobject.base.textsource, ocrtext):
+            gobject.base.textsource.resume_recognition()
+        super().hideEvent(e)
 
     def setf(self):
         WSForEach(transhistwsoutputsave, lambda _: _.setf())

--- a/src/LunaTranslator/textio/textsource/ocrtext.py
+++ b/src/LunaTranslator/textio/textsource/ocrtext.py
@@ -135,6 +135,7 @@ class ocrtext(basetext):
 
     def init(self):
         self.stop = True
+        self._pause_state = None
         self.startsql(gobject.gettranslationrecorddir("0_ocr.sqlite"))
         threader(ocr_init)()
         self.ranges: "list[rangemanger]" = []
@@ -296,6 +297,15 @@ class ocrtext(basetext):
 
     def gettextonce(self):
         return self.getallres(False)
+
+    def pause_recognition(self):
+        self._pause_state = self.stop
+        self.stop = True
+
+    def resume_recognition(self):
+        if self._pause_state is not None:
+            self.stop = self._pause_state
+            self._pause_state = None
 
     def end(self):
         globalconfig["ocrregions"] = [_.range_ui.getrect() for _ in self.ranges]


### PR DESCRIPTION
### Background And Problem
The current implementation continuously performs recognition and write operations to the history window even while the user is actively reviewing it.
When I open the History View, my intent is usually to scroll back and review specific snippets I just processed. However, because the OCR engine remains active in the background, it continues to recognize new content and perform write operations to the history list.
These background updates trigger immediate UI refreshes. As a result:
- The history list constantly jumps or auto-scrolls to the bottom.
- It becomes nearly impossible to stay focused on a specific historical entry.
- The user experience is interrupted by this infinite refresh loop.

**The Solution:**
This PR introduces a state check to temporarily suspend both the OCR inference and the history logging/writing process as long as the History panel is open. Normal operations resume automatically once the panel is closed.

### Scope Of Change
- src/LunaTranslator/textio/textsource/ocrtext.py
- src/LunaTranslator/gui/transhist.py


### Verification
**Open history records page**
- Step: Navigate to the history window from the main interface
- Result: OCR recognition is paused; history list loads completely and stops refreshing
- Verification: Can stably view, scroll, and select target history entries without interface flicker
<img width="489" alt="3d3a23647c98edd343d061b02c438fde" src="https://github.com/user-attachments/assets/8122e464-0ab1-4dae-a2f9-a10d69e528a1" />


**Close history records page**
- Step: Return to the main interface after viewing history
- Result: OCR engine is automatically resumed

I opened and closed the history window multiple times and observed that the OCR pause/resume logic is stable. The fix meets expectations.

### Rollback Plan
git revert fc77bd81bbe2c970b2a7b576e89d303a30d817ea