### PR TITLE
修复 Gemini 流式翻译不完整

### DIFF
--- a/src/LunaTranslator/myutils/utils.py
+++ b/src/LunaTranslator/myutils/utils.py
@@ -1055,7 +1055,6 @@ def common_create_gemini_request(
     apitype: APIType,
 ):
     gen_config = {
-        "stopSequences": [" \n"],
         "temperature": config["Temperature"],
         "maxOutputTokens": config["max_tokens"],
         "topP": config["top_p"],
@@ -1101,12 +1100,12 @@ def common_create_gemini_request(
     ]
     # https://discuss.ai.google.dev/t/gemma-3-missing-features-despite-announcement/71692/13
     sys_message = (
-        {"systemInstruction": {"parts": {"text": sysprompt}}} if sysprompt else {}
+        {"systemInstruction": {"parts": [{"text": sysprompt}]}} if sysprompt else {}
     )
     usingstream = config.get("流式输出", False)
     payload = {}
     payload.update(contents=contents)
-    payload.update(safety_settings=safety)
+    payload.update(safetySettings=safety)
     if not model.startswith("gemma-3"):
         payload.update(sys_message)
     payload.update(generationConfig=gen_config)
@@ -1122,13 +1121,32 @@ def common_create_gemini_request(
     return res
 
 
+def common_parse_gemini_candidate_text(candidate: dict):
+    content: dict = candidate.get("content", {})
+    return "".join(
+        part.get("text", "")
+        for part in content.get("parts", [])
+        if isinstance(part, dict) and not part.get("thought")
+    )
+
+
+def common_parse_gemini_response_text(js: dict):
+    candidates = js.get("candidates", [])
+    if not candidates:
+        return ""
+    return common_parse_gemini_candidate_text(candidates[0])
+
+
 def common_parse_normal_response_1(response: requests.Response, apitype: APIType):
     try:
         js = response.json()
         if apitype == APIType.claude:
             return js["content"][0]["text"], None
         elif apitype == APIType.gemini:
-            return js["candidates"][0]["content"]["parts"][0]["text"], None
+            resp = common_parse_gemini_response_text(js)
+            if not resp:
+                raise Exception()
+            return resp, None
         else:
             message: dict = js["choices"][0]["message"]
             return message["content"], message.get("reasoning")

--- a/src/LunaTranslator/translator/gptcommon.py
+++ b/src/LunaTranslator/translator/gptcommon.py
@@ -5,6 +5,7 @@ from myutils.utils import (
     APIType,
     common_list_models,
     common_parse_normal_response,
+    common_parse_gemini_response_text,
     common_create_gemini_request,
     common_create_gpt_data,
 )
@@ -37,6 +38,9 @@ def stream_event_parser(response: requests.Response):
         except:
             raise Exception(response_data)
         yield json_data
+
+
+_gemini_text_line = re.compile(r'^"text"\s*:\s*("(?:\\.|[^"\\])*")\s*,?$')
 
 
 def commonparseresponse_good(
@@ -97,7 +101,7 @@ def commonparseresponse_good(
                         else:
                             yield msg
             rs = json_data["choices"][0].get("finish_reason")
-            if rs and rs != "null":
+            if rs and rs != "null" and not (msg or reasoning_content):
                 break
         except:
             raise Exception(json_data)
@@ -108,20 +112,34 @@ def parseresponsegemini(response: requests.Response, markdown2html: bool):
     line = ""
     for __x in response.iter_lines(decode_unicode=True):
         __x = __x.strip()
-        if not __x.startswith('"text":'):
+        if not __x:
             continue
+        if __x.startswith("data: "):
+            __x = __x[6:].strip()
+            if __x == "[DONE]":
+                break
         try:
-            __x = json.loads("{" + __x + "}")["text"]
+            text = common_parse_gemini_response_text(json.loads(__x))
         except:
-            # gemini-3-flash 之后还有别的东西
+            text = None
+        if text is None:
+            match = _gemini_text_line.match(__x)
+            if not match:
+                continue
+            try:
+                text = json.loads(match.group(1))
+            except:
+                # Some Gemini variants add non-text fields around text chunks.
+                continue
+        if not text:
             continue
-        line += __x
+        line += text
         if markdown2html:
             _msg = NativeUtils.Markdown2Html(line)
             yield "\0"
             yield "LUNASHOWHTML" + _msg
         else:
-            yield __x
+            yield text
     return line
 
 


### PR DESCRIPTION
## 问题

使用 Gemini 或部分 Gemini-compatible 接口进行大模型流式翻译时，可能出现翻译结果不完整，只显示第一段/第一块内容的问题。

## 原因

部分 Gemini-compatible 接口使用 OpenAI-compatible 的流式返回格式，但每个 chunk 都会带上 `finish_reason: "stop"`。原来的通用流式解析逻辑只要看到 `finish_reason` 就停止读取，因此后续 chunk 会被丢弃，结果只显示第一段，并且可能被写入翻译缓存。

Gemini 原生接口的流式解析也只匹配单独一行的 `"text": ...`，无法可靠处理 SSE `data:` JSON、多个 `parts`，以及包含 thought/signature 等额外字段的新格式响应。

## 修改

- OpenAI-compatible 流式解析在 chunk 仍包含文本时不再因为 `finish_reason` 提前停止。
- Gemini 流式响应改为解析完整 JSON/SSE chunk，并合并 `content.parts` 中的非 thought 文本。
- Gemini 非流式响应合并所有 text parts，不再只取 `parts[0]`。
- 更新 Gemini 请求体字段：
  - `systemInstruction.parts` 使用数组格式。
  - `safetySettings` 使用 Gemini API 的字段名。
- 移除默认的 `stopSequences: [" \n"]`，避免在正常空白/换行附近提前停止输出。
- 不修改默认 prompt，也不修改用户自定义 prompt。
- 不再在通用翻译流程中做换行后处理。

## 验证

- `python3 -m py_compile src/LunaTranslator/translator/gptcommon.py src/LunaTranslator/myutils/utils.py`
- 本地行为测试覆盖：
  - 每个 chunk 都带 `finish_reason` 的 OpenAI-compatible 流式响应。
  - Gemini SSE JSON 多 parts 响应。
  - Gemini `"text"` 行 fallback。