### PR TITLE
fix(IconButton): 恢复对双状态 list 图标的支持(修 AnkiWindow 崩溃)

### DIFF
--- a/src/LunaTranslator/gui/usefulwidget.py
+++ b/src/LunaTranslator/gui/usefulwidget.py
@@ -3259,17 +3259,27 @@ class IconButton(LPushButton):
         self._color = color
         self.__seticon()
 
-    def _setIconStr(self, icon: str):
-        if icon is not None and len(icon) > 1 and (icon == "luna" or not icon.startswith("fa.")):
-            self.pixmap_ = (
-                getExeIcon(getcurrexe(), icon=False, large=True)
-                if icon == "luna"
-                else load_specific_icon_size(icon)
-            )
+    def _setIconStr(self, icon):
+        if self._is_pixmap_icon(icon):
+            self.pixmap_ = self._load_pixmap(icon)
             self._icon = None
         else:
             self.pixmap_ = None
             self._icon = icon
+
+    @staticmethod
+    def _is_pixmap_icon(icon) -> bool:
+        return (
+            isinstance(icon, str)
+            and len(icon) > 1
+            and (icon == "luna" or not icon.startswith("fa."))
+        )
+
+    @staticmethod
+    def _load_pixmap(icon: str):
+        if icon == "luna":
+            return getExeIcon(getcurrexe(), icon=False, large=True)
+        return load_specific_icon_size(icon)
     def setIconStr(self, icon: str):
         self._setIconStr(icon)
         self.__seticon()


### PR DESCRIPTION
Fixes #2283

## 问题

回归 commit 21781e0 引入的 `_setIconStr` 假设 `icon` 必为 `str`,但 `IconButton` 既有契约接受 `str | list[str] | None`(用于 checkable 按钮按选中态切换图标)。结果任何传 list 的调用方一构造按钮就崩:

```
AttributeError: 'list' object has no attribute 'startswith'
  File "src/LunaTranslator/gui/usefulwidget.py", line 3263, in _setIconStr
    if icon is not None and len(icon) > 1 and (icon == "luna" or not icon.startswith("fa.")):
```

后续 3a32847 补的 `len(icon) > 1` 守护对 list 同样无效。

触发面:`showword.py` 录音按钮 ×2、`edittext.py` 播放按钮 ×1——**任何打开查词「添加」面板的用户都立即崩溃**。

## 改动

`src/LunaTranslator/gui/usefulwidget.py` —— 把分类与加载从 `_setIconStr` 抽成两个 staticmethod,职责单一:

- `_is_pixmap_icon(icon)`: 路由判定,pixmap 路径明确「只吃单字符串且为 `"luna"` 或非 `fa.*`」
- `_load_pixmap(icon)`: 实际资源加载
- `_setIconStr(icon)`: 只剩 if/else 框架

list / tuple / None 自然落入 `_icon`,交由既有 `__seticon` 的 `isinstance(self._icon, str)` 双状态选取逻辑处理(无需改动)。

## 兼容性

| 输入 | 旧行为 | 新行为 |
|---|---|---|
| `None` | `_icon=None`, `pixmap_=None` | 不变 |
| `"fa.play"` | `_icon=str` | 不变 |
| `"luna"` | `pixmap_=exe icon` | 不变 |
| `"C:/path/x.png"` | `pixmap_=loaded` | 不变 |
| `["fa.play", "fa.stop"]` | **崩溃** | `_icon=list`,按 checked 切换 ✓ |

## 验证

- 重启后打开查词 → 「添加」tab 不再崩溃
- 录音按钮(`["fa.microphone", "fa.stop"]`)点击后 🎤 ↔ ⏹ 切换正常
- 文本编辑窗口播放按钮(`["fa.play", "fa.forward"]`)切换正常
- 主界面常规 `fa.*` 图标 / `"luna"` logo 图标无回归
