### PR TITLE
Fix broken Claude API requests

### DIFF
--- a/src/LunaTranslator/translator/gptcommon.py
+++ b/src/LunaTranslator/translator/gptcommon.py
@@ -288,7 +288,7 @@ class gptcommon(basetrans):
         apitype = APIType(self.config.get("API接口地址", ""))
         if apitype == APIType.gemini:
             response = self.request_gemini(apitype, messages, extrabody, extraheader)
-        elif apitype == APIType.gemini:
+        elif apitype == APIType.claude:
             response = self.req_claude(
                 messages, extrabody, extraheader, self.config.get("cachecontext", False)
             )


### PR DESCRIPTION
This fixes requests to Claude API.  The gemini API type was duplicated for Claude which was causing requests to Anthropic to fall through to the else block.