### PR TITLE
统一 LLM 模型配置入口并支持模型卡复用

### DIFF
--- a/src/LunaTranslator/cishu/chatgptlike.py
+++ b/src/LunaTranslator/cishu/chatgptlike.py
@@ -7,6 +7,7 @@ from myutils.utils import (
 )
 import NativeUtils
 from myutils.proxy import getproxy
+from myutils.llmcard import resolve_llm_config
 from cishu.cishubase import cishubase
 from translator.gptcommon import createheaders
 from gui.customparams import customparams, getcustombodyheaders
@@ -26,6 +27,10 @@ class chatgptlike(cishubase):
     use_github_md_css = True
     backgroundparser = 'document.querySelector("#luna_dict_internal_view > article").style.backgroundColor="rgba(0,0,0,0)"'
 
+    @property
+    def keyfrom(self):
+        return resolve_llm_config(self.config)
+
     def init(self):
         self.maybeuse = {}
 
@@ -37,10 +42,16 @@ class chatgptlike(cishubase):
         __.update(self.rawconfig)
         if "modellistcache" in __:
             __.pop("modellistcache")
-        temperature = random.randint(0, int(20 * self.config["Temperature"]))
+        llm_config = resolve_llm_config(self.config)
+        if "modellistcache" in llm_config:
+            llm_config.pop("modellistcache")
+        temperature = random.randint(0, int(20 * llm_config["Temperature"]))
+        __["llm_model_config"] = llm_config
         return (word, sentence, temperature, str(__))
 
-    def search_1(self, apitype: APIType, sysprompt, query, extrabody, extraheader):
+    def search_1(
+        self, llm_config: dict, apitype: APIType, sysprompt, query, extrabody, extraheader
+    ):
         message = [{"role": "system", "content": sysprompt}]
         message.append({"role": "user", "content": query})
         headers = createheaders(
@@ -50,7 +61,7 @@ class chatgptlike(cishubase):
             self.proxy,
             extraheader,
         )
-        _json = common_create_gpt_data(self.config, message, extrabody)
+        _json = common_create_gpt_data(llm_config, message, extrabody)
         response = self.proxysession.post(
             apitype.finalurl(), headers=headers, json=_json
         )
@@ -78,20 +89,25 @@ class chatgptlike(cishubase):
         return user_prompt
 
     def search(self, word, sentence=None):
+        llm_config = resolve_llm_config(self.config)
         extrabody, extraheader = getcustombodyheaders(
-            self.config.get("customparams"), **locals()
+            llm_config.get("customparams"), **locals()
         )
         query = self._gptlike_createquery(
             word, sentence, "use_user_user_prompt", "user_user_prompt_1"
         )
         sysprompt = self._gptlike_createsys("使用自定义promt", "自定义promt")
-        apitype = APIType(self.config["API接口地址"])
+        apitype = APIType(llm_config["API接口地址"])
         if apitype == APIType.gemini:
-            resp = self.query_gemini(apitype, sysprompt, query, extrabody, extraheader)
+            resp = self.query_gemini(
+                llm_config, apitype, sysprompt, query, extrabody, extraheader
+            )
         elif apitype == APIType.claude:
-            resp = self.query_cld(sysprompt, query, extrabody, extraheader)
+            resp = self.query_cld(llm_config, sysprompt, query, extrabody, extraheader)
         else:
-            resp = self.search_1(apitype, sysprompt, query, extrabody, extraheader)
+            resp = self.search_1(
+                llm_config, apitype, sysprompt, query, extrabody, extraheader
+            )
         think, resp = common_parse_normal_response(resp, apitype, splitthink=True)
         resp = NativeUtils.Markdown2Html(resp)
         if think:
@@ -101,8 +117,8 @@ class chatgptlike(cishubase):
             resp = think + resp
         return resp
 
-    def query_cld(self, sysprompt, query, extrabody, extraheader):
-        temperature = self.config["Temperature"]
+    def query_cld(self, llm_config: dict, sysprompt, query, extrabody, extraheader):
+        temperature = llm_config["Temperature"]
 
         message = []
         message.append({"role": "user", "content": query})
@@ -112,10 +128,10 @@ class chatgptlike(cishubase):
             "X-Api-Key": self.multiapikeycurrent["SECRET_KEY"],
         }
         data = dict(
-            model=self.config["model"],
+            model=llm_config["model"],
             messages=message,
             system=sysprompt,
-            max_tokens=self.config["max_tokens"],
+            max_tokens=llm_config["max_tokens"],
             temperature=temperature,
         )
         data.update(extrabody)
@@ -127,10 +143,12 @@ class chatgptlike(cishubase):
         )
         return response
 
-    def query_gemini(self, apitype, sysprompt, query, extrabody, extraheader):
+    def query_gemini(
+        self, llm_config: dict, apitype, sysprompt, query, extrabody, extraheader
+    ):
         return common_create_gemini_request(
             self.proxysession,
-            self.config,
+            llm_config,
             self.multiapikeycurrent["SECRET_KEY"],
             sysprompt,
             [{"role": "user", "parts": [{"text": query}]}],

--- a/src/LunaTranslator/gui/inputdialog.py
+++ b/src/LunaTranslator/gui/inputdialog.py
@@ -4,6 +4,7 @@ from traceback import print_exc
 import os, gobject, requests, sys, uuid
 from myutils.commonbase import maybejson
 from myutils.config import globalconfig, _TR, static_data
+from myutils.llmcard import LLM_MODEL_CARD_KEYS, llm_model_card_choices
 from myutils.utils import selectdebugfile, makehtml
 from myutils.wrapper import Singleton
 from gui.usefulwidget import (
@@ -508,11 +509,14 @@ class yuyinzhidingsetting(LDialog):
 
 def autoinitdialog_items(dic):
     items = []
+    hide_llm_card_keys = "llm_model_card" in dic.get("args", {})
     for arg in dic["args"]:
         default = dict(name=arg, k=arg, type="lineedit")
 
         if "argstype" in dic and arg in dic["argstype"]:
             default.update(dic["argstype"][arg])
+        if hide_llm_card_keys and arg in LLM_MODEL_CARD_KEYS:
+            default["hide"] = True
         items.append(default)
     items.append(dict(type="okcancel", rank=-sys.float_info.min))
     return items
@@ -623,6 +627,41 @@ class autoinitdialog(LDialog, DarkLightAutoResetIconHelper):
                 lineW.setCurrentIndex(dd.get(key, 0))
                 self.regist[key] = lineW.currentIndex
             self.cachecombo[key] = lineW
+        elif line["type"] == "llm_model_card":
+            lineW = QHBoxLayout()
+            combo = SuperCombo(static=True, sizeX=True)
+            vis, internal = llm_model_card_choices(line.get("capability"))
+            if not internal:
+                vis, internal = [_TR("未配置")], [""]
+            combo.addItems(vis, internal)
+            combo.setCurrentData(dd.get(key, ""))
+            self.regist[key] = combo.getCurrentData
+            lineW.addWidget(combo)
+        elif line["type"] == "llm_capabilities":
+            values = dd.get(key, [])
+            if not isinstance(values, (list, tuple)):
+                values = ["text"]
+            selected = set(values)
+            names = [
+                ("text", "文本"),
+                ("vision", "图像"),
+                ("tts", "语音"),
+            ]
+            checks = {}
+            lineW = QHBoxLayout()
+            for cap, vis in names:
+                lineW.addWidget(getsmalllabel(vis)())
+                switch = MySwitch(sign=cap in selected)
+                checks[cap] = switch
+                lineW.addWidget(switch)
+            lineW.addStretch()
+
+            def _get_capabilities(checks=checks):
+                return [cap for cap, switch in checks.items() if switch.isChecked()] or [
+                    "text"
+                ]
+
+            self.regist[key] = _get_capabilities
         elif line["type"] == "llm_api_urls":
             lineW = QHBoxLayout()
             combo = SuperComboX()

--- a/src/LunaTranslator/gui/setting/llmcard.py
+++ b/src/LunaTranslator/gui/setting/llmcard.py
@@ -1,0 +1,247 @@
+from qtsymbols import *
+import copy
+import functools
+import uuid
+
+from myutils.config import globalconfig, translatorsetting, ocrsetting, _TR
+from myutils.llmcard import (
+    LLM_MODEL_CARD_DEFAULT,
+    ensure_llm_model_cards,
+    normalize_llm_model_card,
+    ordered_llm_model_card_ids,
+)
+from myutils.proxy import getproxy
+from myutils.utils import APIType, common_list_models
+from gui.customparams import customparams
+from gui.inputdialog import autoinitdialog, autoinitdialog_items
+from gui.usefulwidget import getIconButton, getsmalllabel, makescroll, request_delete_ok
+from gui.dynalang import LGroupBox
+
+
+def list_models(typename, regist: dict):
+    return common_list_models(
+        getproxy(),
+        APIType(regist["API接口地址"]()),
+        regist.get("SECRET_KEY", lambda: "")().split("|")[0],
+    )
+
+
+def _llm_model_card_argstype():
+    return {
+        "name": {"name": "名称", "rank": 0},
+        "capabilities": {"name": "能力", "type": "llm_capabilities", "rank": 0.1},
+        "API接口地址": {"rank": 1, "type": "llm_api_urls"},
+        "SECRET_KEY": {"rank": 2, "name": "API Key", "type": "textlist"},
+        "model": {
+            "rank": 3,
+            "type": "lineedit_or_combo",
+            "list_function": "list_models",
+            "list_cache": "modellistcache",
+        },
+        "modellistcache": {"type": "list_cache"},
+        "Temperature": {"type": "spin", "min": 0, "max": 2, "step": 0.01},
+        "max_tokens": {
+            "type": "intspin",
+            "min": 1,
+            "max": 1000000,
+            "appends": ["use_max_completion_tokens"],
+        },
+        "use_max_completion_tokens": {
+            "name": "使用 max_completion_tokens",
+            "type": "switch",
+        },
+        "top_p": {
+            "refswitch": "top_p_use",
+            "type": "spin",
+            "min": 0,
+            "max": 1,
+            "step": 0.01,
+        },
+        "frequency_penalty": {
+            "type": "spin",
+            "refswitch": "frequency_penalty_use",
+            "min": -2,
+            "max": 2,
+            "step": 0.01,
+        },
+        "reasoning_effort": {
+            "type": "combo",
+            "refswitch": "reasoning_effort_use",
+            "internal": ["none", "minimal", "low", "medium", "high", "xhigh"],
+            "list": ["none", "minimal", "low", "medium", "high", "xhigh"],
+        },
+        "thinking.type": {
+            "type": "combo",
+            "refswitch": "thinking.type.use",
+            "internal": ["disabled", "enabled"],
+            "list": ["disabled", "enabled"],
+        },
+        "customparams": {
+            "name": "其他参数",
+            "type": "custom",
+            "function": "customparams",
+            "rank": -1,
+        },
+    }
+
+
+def _iter_llm_card_setting_groups():
+    yield translatorsetting
+    yield globalconfig.get("cishu", {})
+    yield ocrsetting
+    yield globalconfig.get("reader", {})
+
+
+def _llm_card_usages(uid):
+    usages = []
+    for settings in _iter_llm_card_setting_groups():
+        for name, setting in settings.items():
+            if not isinstance(setting, dict):
+                continue
+            args = setting.get("args")
+            if not isinstance(args, dict):
+                continue
+            if args.get("llm_model_card") == uid:
+                usages.append(setting.get("name") or name)
+    return usages
+
+
+class LLMModelCardPage(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        ensure_llm_model_cards()
+        layout = QVBoxLayout(self)
+
+        toolbar = QHBoxLayout()
+        toolbar.setContentsMargins(0, 0, 0, 0)
+        toolbar.addWidget(getIconButton(self.add_card, icon="fa.plus", tips="添加"))
+        toolbar.addStretch()
+        layout.addLayout(toolbar)
+
+        scroll = makescroll()
+        self.cards_widget = QWidget()
+        self.cards_layout = QVBoxLayout(self.cards_widget)
+        self.cards_layout.setContentsMargins(0, 0, 0, 0)
+        self.cards_layout.setSpacing(6)
+        scroll.setWidget(self.cards_widget)
+        layout.addWidget(scroll)
+        self.reload()
+
+    def reload(self):
+        while self.cards_layout.count():
+            item = self.cards_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+        for uid in ordered_llm_model_card_ids():
+            self.cards_layout.addWidget(self._card_widget(uid))
+        self.cards_layout.addStretch()
+
+    def _card_widget(self, uid):
+        card = normalize_llm_model_card(globalconfig["llm_model_cards"].get(uid))
+        box = LGroupBox(card.get("name") or card.get("model") or "大模型")
+        grid = QGridLayout(box)
+        grid.setColumnStretch(1, 1)
+        grid.addWidget(getsmalllabel("模型")(), 0, 0)
+        grid.addWidget(QLabel(card.get("model", "")), 0, 1)
+        grid.addWidget(getsmalllabel("API")(), 1, 0)
+        api = QLabel(card.get("API接口地址", ""))
+        api.setWordWrap(True)
+        grid.addWidget(api, 1, 1)
+        grid.addWidget(getsmalllabel("能力")(), 2, 0)
+        grid.addWidget(QLabel(" / ".join(card.get("capabilities", []))), 2, 1)
+        grid.addWidget(getsmalllabel("Key")(), 3, 0)
+        grid.addWidget(QLabel("已配置" if card.get("SECRET_KEY") else "未配置"), 3, 1)
+
+        actions = QHBoxLayout()
+        actions.addWidget(
+            getIconButton(
+                functools.partial(self.edit_card, uid),
+                icon="fa.gear",
+                tips="设置",
+            )
+        )
+        actions.addWidget(
+            getIconButton(
+                functools.partial(self.copy_card, uid),
+                icon="fa.copy",
+                tips="复制",
+            )
+        )
+        actions.addWidget(
+            getIconButton(
+                functools.partial(self.delete_card, uid),
+                icon="fa.minus",
+                tips="删除",
+            )
+        )
+        actions.addStretch()
+        grid.addLayout(actions, 0, 2, 4, 1)
+        return box
+
+    def _normalize_card(self, uid):
+        globalconfig["llm_model_cards"][uid] = normalize_llm_model_card(
+            globalconfig["llm_model_cards"].get(uid)
+        )
+
+    def edit_card(self, uid):
+        self._normalize_card(uid)
+        card = globalconfig["llm_model_cards"][uid]
+        dialogconf = {"args": card, "argstype": _llm_model_card_argstype()}
+        items = autoinitdialog_items(dialogconf)
+        items[-1]["callback"] = functools.partial(self.after_edit, uid)
+        autoinitdialog(
+            self,
+            card,
+            card.get("name") or "大模型",
+            800,
+            items,
+            "gui.setting.llmcard",
+            uid,
+        )
+
+    def after_edit(self, uid):
+        self._normalize_card(uid)
+        self.reload()
+
+    def add_card(self):
+        uid = str(uuid.uuid4())
+        card = copy.deepcopy(LLM_MODEL_CARD_DEFAULT)
+        card["name"] = _TR("大模型")
+        globalconfig["llm_model_cards"][uid] = card
+        globalconfig["llm_model_cards_rank"].append(uid)
+        self.reload()
+        self.edit_card(uid)
+
+    def copy_card(self, uid):
+        newuid = str(uuid.uuid4())
+        card = copy.deepcopy(
+            normalize_llm_model_card(globalconfig["llm_model_cards"][uid])
+        )
+        card["name"] = "{}_copy".format(
+            card.get("name") or card.get("model") or "大模型"
+        )
+        globalconfig["llm_model_cards"][newuid] = card
+        globalconfig["llm_model_cards_rank"].append(newuid)
+        self.reload()
+        self.edit_card(newuid)
+
+    def delete_card(self, uid):
+        usages = _llm_card_usages(uid)
+        if usages:
+            QMessageBox.information(
+                self,
+                _TR("无法删除"),
+                _TR("当前模型卡正在使用：") + "\n" + "\n".join(usages),
+            )
+            return
+        if not request_delete_ok(self, "llm_model_card"):
+            return
+        globalconfig["llm_model_cards"].pop(uid, None)
+        if uid in globalconfig["llm_model_cards_rank"]:
+            globalconfig["llm_model_cards_rank"].remove(uid)
+        self.reload()
+
+
+def setTabllmcard(self, basel: QVBoxLayout):
+    basel.addWidget(LLMModelCardPage(self))

--- a/src/LunaTranslator/gui/setting/setting.py
+++ b/src/LunaTranslator/gui/setting/setting.py
@@ -6,6 +6,7 @@ from myutils.config import globalconfig
 from gui.usefulwidget import closeashidewindow, makesubtab_lazy
 from gui.setting.textinput import setTabOne_lazy
 from gui.setting.translate import setTabTwo_lazy
+from gui.setting.llmcard import setTabllmcard
 from gui.setting.display import setTabThree_lazy
 from gui.setting.tts import setTab5
 from gui.setting.cishu import setTabcishu
@@ -95,6 +96,7 @@ class Setting(closeashidewindow):
             [
                 "核心设置",
                 "翻译设置",
+                "模型配置",
                 "显示设置",
                 "文本处理",
                 "辞书设置",
@@ -105,6 +107,7 @@ class Setting(closeashidewindow):
             [
                 functools.partial(setTabOne_lazy, self),
                 functools.partial(setTabTwo_lazy, self),
+                functools.partial(setTabllmcard, self),
                 functools.partial(setTabThree_lazy, self),
                 functools.partial(setTab7_lazy, self),
                 functools.partial(setTabcishu, self),

--- a/src/LunaTranslator/myutils/config.py
+++ b/src/LunaTranslator/myutils/config.py
@@ -557,6 +557,147 @@ def copyllmapi(fanyi, newname=None, uid=None, args: dict = None, use=False):
     return uid
 
 
+LLM_MIGRATION_VERSION = 1
+
+_LLM_CARD_DEFAULT = {
+    "name": "大模型",
+    "API接口地址": "https://api.openai.com",
+    "SECRET_KEY": "",
+    "model": "gpt-4o-mini",
+    "modellistcache": [],
+    "Temperature": 0,
+    "max_tokens": 1024,
+    "top_p": 0.3,
+    "top_p_use": True,
+    "frequency_penalty": 0,
+    "frequency_penalty_use": False,
+    "reasoning_effort": "medium",
+    "reasoning_effort_use": False,
+    "thinking.type": "disabled",
+    "thinking.type.use": False,
+    "use_max_completion_tokens": False,
+    "customparams": [],
+    "capabilities": ["text"],
+}
+
+_LLM_CARD_KEYS = tuple(k for k in _LLM_CARD_DEFAULT if k not in ("name", "capabilities"))
+
+
+def _ensure_llm_model_cards_config():
+    globalconfig.setdefault("llm_model_cards", {})
+    globalconfig.setdefault("llm_model_cards_rank", [])
+    globalconfig.setdefault("llm_migration_version", 0)
+
+
+def _add_llm_model_card_selector(setting: dict, capability: str):
+    if not isinstance(setting, dict) or "args" not in setting:
+        return
+    args = setting["args"]
+    if "llm_model_card" not in args:
+        newargs = {"llm_model_card": ""}
+        newargs.update(args)
+        setting["args"] = newargs
+    setting.setdefault("argstype", {})
+    setting["argstype"]["llm_model_card"] = {
+        "name": "模型卡",
+        "type": "llm_model_card",
+        "capability": capability,
+        "rank": 0,
+    }
+
+
+def _ensure_llm_model_card_selectors():
+    _add_llm_model_card_selector(
+        translatorsetting.get("chatgpt-3rd-party"), "text"
+    )
+    _add_llm_model_card_selector(globalconfig["cishu"].get("chatgptlike"), "text")
+    _add_llm_model_card_selector(ocrsetting.get("chatgptlike"), "vision")
+    _add_llm_model_card_selector(globalconfig["reader"].get("chatgpttts"), "tts")
+    for uid in globalconfig["fanyi"]:
+        if getcopyfrom(uid) != "chatgpt-3rd-party":
+            continue
+        _add_llm_model_card_selector(translatorsetting.get(uid), "text")
+
+
+def _llm_card_from_args(args: dict, api_key="API接口地址", capability="text"):
+    card = copy.deepcopy(_LLM_CARD_DEFAULT)
+    for key in _LLM_CARD_KEYS:
+        oldkey = api_key if key == "API接口地址" else key
+        if oldkey in args:
+            card[key] = copy.deepcopy(args[oldkey])
+    card["capabilities"] = [capability]
+    model = str(card.get("model") or "").strip()
+    apiurl = str(card.get("API接口地址") or "").strip()
+    card["name"] = model or apiurl or "大模型"
+    return card
+
+
+def _llm_card_empty(card: dict):
+    return not any(
+        str(card.get(k, "")).strip() for k in ("API接口地址", "SECRET_KEY", "model")
+    )
+
+
+def _llm_card_signature(card: dict):
+    return json.dumps(
+        {k: card.get(k) for k in _LLM_CARD_KEYS if k != "modellistcache"},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _get_or_create_llm_card(card: dict):
+    cards = globalconfig["llm_model_cards"]
+    signature = _llm_card_signature(card)
+    for uid, oldcard in cards.items():
+        if _llm_card_signature(oldcard) != signature:
+            continue
+        oldcaps = oldcard.setdefault("capabilities", [])
+        for cap in card.get("capabilities", []):
+            if cap not in oldcaps:
+                oldcaps.append(cap)
+        return uid
+    uid = str(uuid.uuid4())
+    cards[uid] = card
+    globalconfig["llm_model_cards_rank"].append(uid)
+    return uid
+
+
+def _migrate_llm_card_from_setting(setting: dict, api_key, capability):
+    if not isinstance(setting, dict) or "args" not in setting:
+        return
+    args = setting["args"]
+    if args.get("llm_model_card") in globalconfig["llm_model_cards"]:
+        return
+    card = _llm_card_from_args(args, api_key, capability)
+    if _llm_card_empty(card):
+        return
+    args["llm_model_card"] = _get_or_create_llm_card(card)
+
+
+def _migrate_llm_model_cards():
+    _ensure_llm_model_cards_config()
+    _ensure_llm_model_card_selectors()
+    if globalconfig.get("llm_migration_version", 0) >= LLM_MIGRATION_VERSION:
+        return
+    for uid in list(globalconfig["fanyi"].keys()):
+        if getcopyfrom(uid) == "chatgpt-3rd-party":
+            _migrate_llm_card_from_setting(
+                translatorsetting.get(uid), "API接口地址", "text"
+            )
+    _migrate_llm_card_from_setting(
+        globalconfig["cishu"].get("chatgptlike"), "API接口地址", "text"
+    )
+    _migrate_llm_card_from_setting(ocrsetting.get("chatgptlike"), "apiurl", "vision")
+    _migrate_llm_card_from_setting(
+        globalconfig["reader"].get("chatgpttts"), "API接口地址", "tts"
+    )
+    globalconfig["llm_migration_version"] = LLM_MIGRATION_VERSION
+
+
+_migrate_llm_model_cards()
+
+
 def urlpathjoin(*argc: str):
     urlx = []
     for i, u in enumerate(argc):

--- a/src/LunaTranslator/myutils/llmcard.py
+++ b/src/LunaTranslator/myutils/llmcard.py
@@ -1,0 +1,118 @@
+import copy
+
+from myutils.config import globalconfig
+
+
+LLM_MODEL_CARD_KEYS = {
+    "API接口地址",
+    "apiurl",
+    "SECRET_KEY",
+    "model",
+    "modellistcache",
+    "Temperature",
+    "max_tokens",
+    "top_p",
+    "top_p_use",
+    "frequency_penalty",
+    "frequency_penalty_use",
+    "reasoning_effort",
+    "reasoning_effort_use",
+    "thinking.type",
+    "thinking.type.use",
+    "use_max_completion_tokens",
+    "customparams",
+}
+
+LLM_MODEL_CARD_DEFAULT = {
+    "name": "大模型",
+    "API接口地址": "https://api.openai.com",
+    "SECRET_KEY": "",
+    "model": "gpt-4o-mini",
+    "modellistcache": [],
+    "Temperature": 0,
+    "max_tokens": 1024,
+    "top_p": 0.3,
+    "top_p_use": True,
+    "frequency_penalty": 0,
+    "frequency_penalty_use": False,
+    "reasoning_effort": "medium",
+    "reasoning_effort_use": False,
+    "thinking.type": "disabled",
+    "thinking.type.use": False,
+    "use_max_completion_tokens": False,
+    "customparams": [],
+    "capabilities": ["text"],
+}
+
+
+def ensure_llm_model_cards():
+    globalconfig.setdefault("llm_model_cards", {})
+    globalconfig.setdefault("llm_model_cards_rank", [])
+    globalconfig.setdefault("llm_migration_version", 0)
+
+
+def normalize_llm_model_card(card: dict):
+    normal = copy.deepcopy(LLM_MODEL_CARD_DEFAULT)
+    normal.update(copy.deepcopy(card or {}))
+    if not isinstance(normal.get("capabilities"), list):
+        normal["capabilities"] = ["text"]
+    if not normal["capabilities"]:
+        normal["capabilities"] = ["text"]
+    return normal
+
+
+def get_llm_model_card(uid):
+    ensure_llm_model_cards()
+    card = globalconfig["llm_model_cards"].get(uid)
+    if not isinstance(card, dict):
+        return None
+    return normalize_llm_model_card(card)
+
+
+def resolve_llm_config(config: dict, legacy_api_key="API接口地址"):
+    ensure_llm_model_cards()
+    resolved = copy.deepcopy(config or {})
+    if legacy_api_key != "API接口地址" and "API接口地址" not in resolved:
+        resolved["API接口地址"] = resolved.get(legacy_api_key, "")
+    card = get_llm_model_card(resolved.get("llm_model_card"))
+    if card:
+        resolved.update(card)
+    else:
+        for key, value in LLM_MODEL_CARD_DEFAULT.items():
+            if key not in resolved:
+                resolved[key] = copy.deepcopy(value)
+    if legacy_api_key != "API接口地址":
+        resolved[legacy_api_key] = resolved.get("API接口地址", "")
+    return resolved
+
+
+def ordered_llm_model_card_ids():
+    ensure_llm_model_cards()
+    cards = globalconfig["llm_model_cards"]
+    rank = globalconfig["llm_model_cards_rank"]
+    ordered = [uid for uid in rank if uid in cards]
+    ordered.extend(uid for uid in cards if uid not in ordered)
+    globalconfig["llm_model_cards_rank"] = ordered
+    return ordered
+
+
+def llm_model_card_name(uid):
+    card = get_llm_model_card(uid)
+    if not card:
+        return uid
+    return card.get("name") or card.get("model") or uid
+
+
+def llm_model_card_choices(capability=None):
+    ids = ordered_llm_model_card_ids()
+
+    def matched(uid):
+        if not capability:
+            return True
+        caps = get_llm_model_card(uid).get("capabilities", [])
+        return capability in caps
+
+    filtered = [uid for uid in ids if matched(uid)]
+    if capability and not filtered:
+        filtered = ids
+    return [llm_model_card_name(uid) for uid in filtered], filtered

--- a/src/LunaTranslator/ocrengines/chatgptlike.py
+++ b/src/LunaTranslator/ocrengines/chatgptlike.py
@@ -9,6 +9,7 @@ from myutils.utils import (
     common_create_gpt_data,
 )
 from myutils.proxy import getproxy
+from myutils.llmcard import resolve_llm_config
 from gui.customparams import customparams, getcustombodyheaders
 
 
@@ -21,6 +22,9 @@ def list_models(typename, regist):
 
 
 class OCR(baseocr):
+    @property
+    def keyfrom(self):
+        return resolve_llm_config(self.config, "apiurl")
 
     def langmap(self):
         return Languages.createenglishlangmap()
@@ -30,9 +34,9 @@ class OCR(baseocr):
         h.update(extraheader)
         return h
 
-    def ocr_mistral(self, _, base64_image, extrabody, extraheader):
+    def ocr_mistral(self, llm_config: dict, base64_image, extrabody, extraheader):
         payload = {
-            "model": self.config["model"],
+            "model": llm_config["model"],
             "document": {
                 "type": "image_url",
                 "image_url": "data:image/jpeg;base64,{}".format(base64_image),
@@ -52,10 +56,12 @@ class OCR(baseocr):
         except:
             raise Exception(response)
 
-    def ocr_gemini(self, apitype, prompt, base64_image, extrabody, extraheader):
+    def ocr_gemini(
+        self, llm_config: dict, apitype, prompt, base64_image, extrabody, extraheader
+    ):
         return common_create_gemini_request(
             self.proxysession,
-            self.config,
+            llm_config,
             self.multiapikeycurrent["SECRET_KEY"],
             None,
             [
@@ -77,7 +83,13 @@ class OCR(baseocr):
         )
 
     def ocr_normal(
-        self, apitype: APIType, prompt, base64_image, extrabody, extraheader
+        self,
+        llm_config: dict,
+        apitype: APIType,
+        prompt,
+        base64_image,
+        extrabody,
+        extraheader,
     ):
 
         message = [
@@ -99,7 +111,7 @@ class OCR(baseocr):
         response = self.proxysession.post(
             apitype.finalurl(),
             headers=h,
-            json=common_create_gpt_data(self.config, message, extrabody),
+            json=common_create_gpt_data(llm_config, message, extrabody),
         )
         return response
 
@@ -112,21 +124,24 @@ class OCR(baseocr):
         return template, isocrtranslate
 
     def ocr(self, imagebinary):
+        llm_config = resolve_llm_config(self.config, "apiurl")
         extrabody, extraheader = getcustombodyheaders(
-            self.config.get("customparams"), **locals()
+            llm_config.get("customparams"), **locals()
         )
         prompt, isocrtranslate = self._gptlike_createsys(
             "use_custom_prompt", "custom_prompt"
         )
         base64_image = base64.b64encode(imagebinary).decode("utf-8")
-        apitype = APIType(self.config["apiurl"])
+        apitype = APIType(llm_config["apiurl"])
         if apitype == APIType.gemini:
-            response = self.ocr_gemini(apitype, prompt, base64_image, extrabody, extraheader)
+            response = self.ocr_gemini(
+                llm_config, apitype, prompt, base64_image, extrabody, extraheader
+            )
         elif apitype == APIType.mistral:
-            return self.ocr_mistral(prompt, base64_image, extrabody, extraheader)
+            return self.ocr_mistral(llm_config, base64_image, extrabody, extraheader)
         else:
             response = self.ocr_normal(
-                apitype, prompt, base64_image, extrabody, extraheader
+                llm_config, apitype, prompt, base64_image, extrabody, extraheader
             )
         return OCRResult(
             texts=common_parse_normal_response(response, apitype),

--- a/src/LunaTranslator/translator/gptcommon.py
+++ b/src/LunaTranslator/translator/gptcommon.py
@@ -10,6 +10,7 @@ from myutils.utils import (
     common_create_gpt_data,
 )
 from myutils.proxy import getproxy
+from myutils.llmcard import resolve_llm_config
 from language import Languages
 from gui.customparams import getcustombodyheaders
 
@@ -265,6 +266,10 @@ def createheaders(apitype: APIType, curkey: str, maybeuse: dict, proxy, extra):
 
 
 class gptcommon(basetrans):
+    @property
+    def keyfrom(self):
+        return resolve_llm_config(self.config)
+
     def langmap(self):
         return Languages.createenglishlangmap()
 
@@ -277,20 +282,28 @@ class gptcommon(basetrans):
         super().__init__(typename)
 
     def translate(self, query_2: GptTextWithDict):
-        self.checkempty("API接口地址")
+        llm_config = resolve_llm_config(self.config)
+        if not llm_config.get("API接口地址"):
+            self.checkempty("API接口地址")
         if isinstance(query_2, str):
             query_2 = GptTextWithDict(query_2)
         extrabody, extraheader = getcustombodyheaders(
-            self.config.get("customparams"), **locals()
+            llm_config.get("customparams"), **locals()
         )
-        usingstream = self.config["流式输出"]
+        usingstream = llm_config["流式输出"]
         messages, query, query_1 = self.commoncreatemessages(query_2)
-        apitype = APIType(self.config.get("API接口地址", ""))
+        apitype = APIType(llm_config.get("API接口地址", ""))
         if apitype == APIType.gemini:
-            response = self.request_gemini(apitype, messages, extrabody, extraheader)
+            response = self.request_gemini(
+                llm_config, apitype, messages, extrabody, extraheader
+            )
         elif apitype == APIType.claude:
             response = self.req_claude(
-                messages, extrabody, extraheader, self.config.get("cachecontext", False)
+                llm_config,
+                messages,
+                extrabody,
+                extraheader,
+                llm_config.get("cachecontext", False),
             )
         else:
             headers = createheaders(
@@ -301,7 +314,9 @@ class gptcommon(basetrans):
                 extraheader,
             )
             _json = common_create_gpt_data(
-                self.config, self.__parse_qwen_mt_turbo(apitype, messages), extrabody
+                llm_config,
+                self.__parse_qwen_mt_turbo(llm_config, apitype, messages),
+                extrabody,
             )
             response = self.proxysession.post(
                 apitype.finalurl(), headers=headers, json=_json, stream=usingstream
@@ -310,7 +325,7 @@ class gptcommon(basetrans):
         markdown2html = self.config.get("markdown2html", False)
         if usingstream:
             respmessage = yield from parsestreamresp(
-                apitype, response, hidethinking, markdown2html, self.config["model"]
+                apitype, response, hidethinking, markdown2html, llm_config["model"]
             )
         else:
             respmessage = common_parse_normal_response(
@@ -327,8 +342,10 @@ class gptcommon(basetrans):
         self.context.append({"role": "assistant", "content": respmessage})
         self.context_for_cache.append({"role": "assistant", "content": respmessage})
 
-    def __parse_qwen_mt_turbo(self, apitype: APIType, messages: list):
-        if self.config["model"].startswith("qwen-mt-") and apitype == APIType.aliyuncs:
+    def __parse_qwen_mt_turbo(
+        self, llm_config: dict, apitype: APIType, messages: list
+    ):
+        if llm_config["model"].startswith("qwen-mt-") and apitype == APIType.aliyuncs:
             if messages and messages[0]["role"] == "system":
                 messages.pop(0)
         return messages
@@ -424,7 +441,9 @@ class gptcommon(basetrans):
             message.append({"role": "assistant", "content": prefill})
         return message, query, query_1
 
-    def request_gemini(self, apitype, messages: list, extrabody, extraheader):
+    def request_gemini(
+        self, llm_config: dict, apitype, messages: list, extrabody, extraheader
+    ):
 
         sysprompt = messages[0]["content"]
         messages.pop(0)
@@ -435,7 +454,7 @@ class gptcommon(basetrans):
             }
         return common_create_gemini_request(
             self.proxysession,
-            self.config,
+            llm_config,
             self.multiapikeycurrent["SECRET_KEY"],
             sysprompt,
             messages,
@@ -444,8 +463,10 @@ class gptcommon(basetrans):
             apitype,
         )
 
-    def req_claude(self, messages: list, extrabody, extraheader, cache_control):
-        temperature = self.config["Temperature"]
+    def req_claude(
+        self, llm_config: dict, messages: list, extrabody, extraheader, cache_control
+    ):
+        temperature = llm_config["Temperature"]
         sysprompt = messages[0]["content"]
         messages.pop(0)
 
@@ -463,12 +484,12 @@ class gptcommon(basetrans):
             "X-Api-Key": self.multiapikeycurrent["SECRET_KEY"],
         }
 
-        usingstream = self.config["流式输出"]
+        usingstream = llm_config["流式输出"]
         data = dict(
-            model=self.config["model"],
+            model=llm_config["model"],
             messages=messages,
             system=sysprompt,
-            max_tokens=self.config["max_tokens"],
+            max_tokens=llm_config["max_tokens"],
             temperature=temperature,
             stream=usingstream,
         )

--- a/src/LunaTranslator/tts/chatgpttts.py
+++ b/src/LunaTranslator/tts/chatgpttts.py
@@ -1,6 +1,7 @@
 from tts.basettsclass import TTSbase, SpeechParam
 from myutils.utils import APIType, common_list_models
 from myutils.proxy import getproxy
+from myutils.llmcard import resolve_llm_config
 import base64, ctypes
 from gui.customparams import getcustombodyheaders, customparams
 
@@ -16,6 +17,10 @@ def list_models(typename, regist):
 
 class TTS(TTSbase):
     arg_support_pitch = False
+
+    @property
+    def keyfrom(self):
+        return resolve_llm_config(self.config)
 
     def getvoicelist(self):
         voice = self.config["voice_list"]
@@ -33,6 +38,7 @@ class TTS(TTSbase):
         return _
 
     def speak(self, content, voice, param: SpeechParam):
+        llm_config = resolve_llm_config(self.config)
 
         if param.speed > 0:
             speed = 1 + 3 * param.speed / 10
@@ -40,22 +46,31 @@ class TTS(TTSbase):
             speed = 1 + 0.75 * param.speed / 10
 
         extrabody, extraheader = getcustombodyheaders(
-            self.config.get("customparams"), **locals()
+            llm_config.get("customparams"), **locals()
         )
-        apitype = APIType(self.config["API接口地址"])
+        apitype = APIType(llm_config["API接口地址"])
         if apitype == APIType.gemini:
             return self.request_gemini(
-                apitype, content, voice, speed, extrabody, extraheader
+                llm_config, apitype, content, voice, speed, extrabody, extraheader
             )
         else:
-            return self.requestnormal(content, voice, speed, extrabody, extraheader)
+            return self.requestnormal(
+                llm_config, apitype, content, voice, speed, extrabody, extraheader
+            )
 
     def requestnormal(
-        self, apitype: APIType, content, voice, speed, extrabody, extraheader
+        self,
+        llm_config: dict,
+        apitype: APIType,
+        content,
+        voice,
+        speed,
+        extrabody,
+        extraheader,
     ):
 
         json_data = {
-            "model": self.config["model"],
+            "model": llm_config["model"],
             "input": content,
             "voice": voice,
             "speed": speed,  # 0.25 to 4.0. 1.0 is the default.
@@ -73,7 +88,14 @@ class TTS(TTSbase):
         return response
 
     def request_gemini(
-        self, apitype: APIType, content, voice, speed, extrabody, extraheader
+        self,
+        llm_config: dict,
+        apitype: APIType,
+        content,
+        voice,
+        speed,
+        extrabody,
+        extraheader,
     ):
 
         body = {
@@ -84,11 +106,11 @@ class TTS(TTSbase):
                     "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": voice}}
                 },
             },
-            "model": self.config["model"],
+            "model": llm_config["model"],
         }
         body.update(extrabody)
         response = self.proxysession.post(
-            "{}/{}:generateContent".format(apitype.url, self.config["model"]),
+            "{}/{}:generateContent".format(apitype.url, llm_config["model"]),
             params={"key": self.multiapikeycurrent["SECRET_KEY"]},
             headers=extraheader,
             json=body,


### PR DESCRIPTION
将翻译、查词、OCR、TTS 等分散的大模型配置抽象为统一的“模型配置 ”入口，支持创建多个 API + Model 组合，并集中配置温度、top_p、max tokens 等通用大模型参数。方便模型复用以及参数修改。

- 新增统一模型配置页，可新增、复制、编辑、删除模型卡
- 保留原有提示词、上下文数量等功能级配置
- 翻译、查词、OCR、TTS 接入统一模型卡解析
- 支持模型能力区分，按照模型能力不同，在部分场景该模型可能不会显示（比如不支持图像输入的模型不会出现在OCR设置菜单中）
- 首次启动支持支持旧配置自动迁移

<img width="774" height="480" alt="PixPin_2026-05-19_20-17-55" src="https://github.com/user-attachments/assets/abe61838-a9a0-46b1-a23e-f3e29d9597ce" />
