### PR TITLE
Use json.loads instead of eval to parse Bing token (fix RCE)

### DIFF
--- a/src/LunaTranslator/translator/bing.py
+++ b/src/LunaTranslator/translator/bing.py
@@ -1,3 +1,4 @@
+import json
 import re
 from translator.basetranslator import basetrans
 from language import Languages
@@ -21,7 +22,7 @@ class TS(basetrans):
         result_str = re.compile("var params_AbusePreventionHelper = (.*?);").findall(
             host_html
         )[0]
-        result = eval(result_str)
+        result = json.loads(result_str)
         return {"key": result[0], "token": result[1]}
 
     def translate(self, content):


### PR DESCRIPTION
## Problem

`translator/bing.py` `get_tk()` evaluates a string scraped from Bing's homepage with `eval()`:

```python
result_str = re.compile("var params_AbusePreventionHelper = (.*?);").findall(host_html)[0]
result = eval(result_str)
```

`host_html` is fetched over the network (`self.proxysession.get(...)`, which honors a user/attacker-configurable proxy). Any compromised Bing response, a MITM, or a malicious proxy that replaces this snippet with a Python expression gets **arbitrary code execution** in the LunaTranslator process. This is the only `eval()` in the file.

## Fix

The captured value is `[<int>,"<token>",<int>]` — a genuine JSON array. Parse it with `json.loads`, which cannot evaluate names, calls, or attribute access:

```python
result = json.loads(result_str)
```

`get_tk` only reads `result[0]` (key) and `result[1]` (token), both returned identically by `json.loads` for the real payload, so behavior is unchanged. `json.loads` is the established parsing idiom across the translator package (`google.py`, `gptcommon.py`, `premt.py`, `cdp_helper.py`).

A parse failure now raises `json.JSONDecodeError` (a `ValueError`) instead of running code. It is already caught by the existing `try/except Exception` around `_private_init()` in `basetranslator.__init__` (and `maybeneedreinit`), surfacing the same user-visible "init translator failed" message as the prior failure path — no new uncaught-exception surface and no caller changes. The fix fails safe.

This is a minimal, single-purpose change to one file; it does not touch transport trust (HTTPS/proxy policy), which is a separate concern out of scope here.

## Testing

- Verified against the live payload `[1780546559299,"A_R_d1wj2rGiBuME4wFQ_KHofuqP3N4i",3600000]`: `eval()` and `json.loads()` yield byte-identical `result[0]` (int) and `result[1]` (str).
- Manual smoke test: enabled the Bing translator and translated a sentence — `init()` succeeds (no init-failed banner) and a translation is returned, exercising `get_tk` → `self.tk` in the live `ttranslatev3` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
