### PR TITLE
Fix ASCII OCR error-correction being a silent no-op

### DIFF
--- a/src/LunaTranslator/ocrengines/baseocrclass.py
+++ b/src/LunaTranslator/ocrengines/baseocrclass.py
@@ -337,7 +337,7 @@ class OCRResultParsed:
                 continue
             else:
                 if fil.isascii():
-                    line = re.sub(r"\b{}\b".format(re.escape(fil)), fil, line)
+                    line = re.sub(r"\b{}\b".format(re.escape(fil)), lambda m: filters[fil], line)
                 else:
                     line = line.replace(fil, filters[fil])
         return line


### PR DESCRIPTION
## Problem

In `OCRResultParsed._100_f` (`src/LunaTranslator/ocrengines/baseocrclass.py`), the ASCII branch of the OCR error-correction (易错内容修正) routine substitutes every ASCII whole-word match with itself:

```python
line = re.sub(r"\b{}\b".format(re.escape(fil)), fil, line)
```

`fil` is the find key and `filters[fil]` is the intended replacement, so passing `fil` as the `re.sub` replacement means user-configured ASCII corrections silently do nothing. The non-ASCII branch on the next line is already correct (`line.replace(fil, filters[fil])`).

## Fix

Use a replacement function so the configured value is applied literally (and is never interpreted as a regex template, e.g. backslash/group refs):

```python
line = re.sub(r"\b{}\b".format(re.escape(fil)), lambda m: filters[fil], line)
```

The word-boundary anchoring, `re.escape`, the empty-key guard, the non-ASCII branch, and the `ocrerrorfix["use"]` short-circuit are unchanged.

## Testing

- With `替换内容={"teh":"the"}`: `"teh cat"` → `"the cat"`, while `"theater"` stays unchanged (word boundary respected).
- Non-ASCII key still substring-replaces; empty key skipped; feature-disabled returns input unchanged.
- Ran `python src/formatalll.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
