### PR TITLE
Fix QWEN-MT streaming parser crash on end-of-stream

### DIFF
--- a/src/LunaTranslator/translator/gptcommon.py
+++ b/src/LunaTranslator/translator/gptcommon.py
@@ -179,12 +179,13 @@ def parseresponseQWENMT(response: requests.Response):
                 continue
             delta: dict = json_data["choices"][0].get("delta", {})
             msg: str = delta.get("content", None)
-            if msg.startswith(message):
-                yield msg[len(message) :]
-            else:
-                yield "\0"
-                yield msg
-            message = msg
+            if msg:
+                if msg.startswith(message):
+                    yield msg[len(message) :]
+                else:
+                    yield "\0"
+                    yield msg
+                message = msg
             rs = json_data["choices"][0].get("finish_reason")
             if rs and rs != "null":
                 break


### PR DESCRIPTION
## Problem

Translating with a `qwen-mt-*` model on the Aliyun (DashScope) endpoint crashes at end-of-stream and the whole translation fails with no fallback. `parseresponseQWENMT` (`src/LunaTranslator/translator/gptcommon.py`) reads `msg = delta.get("content", None)` then calls `msg.startswith(message)`. The terminal chunk carries only `finish_reason` with no `content`, so `msg` is `None` → `AttributeError`, which the bare `except:` re-raises as `Exception(json_data)`. (A `content: ""` terminator additionally corrupts the accumulated text.)

## Fix

Guard the content-handling lines behind `if msg:` so they run only for truthy cumulative content; the `finish_reason` read and `break` stay outside the guard, so the content-less terminator still ends the loop cleanly. This preserves QWEN-MT's cumulative semantics and mirrors the truthiness check already used in `commonparseresponse_good`. For normal content chunks the behavior is byte-identical.

## Testing

- Parser driven in isolation: normal stream + `content: null` terminator → before: AttributeError / aborted translation; after: yields the deltas and returns the full text.
- `content: ""` terminator → returns the full text instead of corrupted empty.
- Ran `python src/formatalll.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
