### PR TITLE
Fix findhook() infinite loop when a game yields zero hooks

### DIFF
--- a/src/LunaTranslator/textio/textsource/texthook.py
+++ b/src/LunaTranslator/textio/textsource/texthook.py
@@ -716,10 +716,15 @@ class texthook(basetext):
         for pid in pids:
             self.Luna_FindHooks(pid, usestruct, _callback, addresses)
 
+        searchdeadline = time.time() + usestruct.searchTime / 1000 + 60
         while True:
             lastsize = len(cntref)
             time.sleep(2)
-            if lastsize == len(cntref) and lastsize != 0:
+            if (
+                (lastsize == len(cntref) and lastsize != 0)
+                or time.time() > searchdeadline
+                or self.ending
+            ):
                 break
         gobject.base.hookselectdialog.getfoundhooksignal.emit(savefound)
 


### PR DESCRIPTION
## Problem

`texthook.findhook()` (`src/LunaTranslator/textio/textsource/texthook.py`) polls `while True`, breaking only once `cntref` is non-empty and stable (`lastsize == len(cntref) and lastsize != 0`). A game with zero findable hooks never satisfies that, so the `@threader` worker spins every 2 s indefinitely and `getfoundhooksignal.emit(savefound)` never fires — the hook search never reaches a terminal state and leaks a busy thread.

## Fix

Add two bounded exit conditions OR'd with the original success check (kept byte-for-byte as the first disjunct, so hook-finding games exit with identical timing): a wall-clock deadline of `usestruct.searchTime/1000 + 60` and `self.ending`.

The +60 s margin sits above the native side's post-search work — `inlinehookpipeline` sleeps `searchTime`, then 1000 ms, then runs the `MH_RemoveHook` teardown before results reach Python via `NotifyHookFound` — so the deadline trips only on the genuine zero-hook hang and keeps a comfortable margin over a slow-but-real delivery. `self.ending` bounds the loop on graceful shutdown. On a zero-hook game the loop now exits and emits an empty `savefound`, which `getfoundhook` already handles as a no-op (it early-returns on `len(hooks) == 0`).

## Verification

- Confirmed `usestruct.searchTime`, `time`, and `self.ending` are all in scope (`self.ending` is already read by `delaycollectallselectedoutput` in the same class).
- Confirmed the empty-result path is a no-op: `getfoundhook` (`gui/selecthook.py`) early-returns on `len(hooks) == 0`.
- Traced the +60 s margin against the native `hookfinder.cc` post-search work (`Sleep(searchTime)` → `Sleep(1000)` → `MH_RemoveHook` teardown) so a slow-but-real delivery is not truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
