### PR TITLE
fix(ocr): associate show-all checkbox label for screen readers

### DIFF
--- a/src/LunaTranslator/htmlcode/service/ocr.html
+++ b/src/LunaTranslator/htmlcode/service/ocr.html
@@ -117,7 +117,7 @@
 
         }
     </script>
-    <div>显示全部结果<input type="checkbox" id="showall" onclick="showall()">
+    <div><label for="showall">显示全部结果</label><input type="checkbox" id="showall" onclick="showall()">
         &emsp; &emsp; &emsp; &emsp;
         <label for="native-spinbox">字体</label>
         <input type="number" id="native-spinbox" min="0" max="100" step="1">


### PR DESCRIPTION
## Summary
- associate the OCR "show all results" checkbox text with the existing showall input
- preserve the current layout and behavior

## Testing
- git diff --check origin/main...fix/ocr-checkbox-label
- CodeRabbit review on skarL007/LunaTranslator#6: no actionable comments
