### PR TITLE
fix(a11y): add WCAG aria labels and document structure to service pages

### DIFF
--- a/src/LunaTranslator/htmlcode/service/dictionary.html
+++ b/src/LunaTranslator/htmlcode/service/dictionary.html
@@ -1,6 +1,10 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
 <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+    <meta charset="UTF-8">
+    <title>LunaTranslator</title>
 </head>
+<body>
 <script>
     function onclickbtn_1_internal(_id) {
         tabPanes = document.querySelectorAll('.tab-widget_1_internal .tab-pane_1_internal');
@@ -126,23 +130,23 @@
     }
 </script>
 <div class="search-container">
-    <input type="text" class="search-input" id="searchInput">
-    <button class="search-button" onclick="performSearch()">
+    <input type="text" class="search-input" id="searchInput" aria-label="Search term">
+    <button class="search-button" onclick="performSearch()" aria-label="Search">
         <svg width="30" height="30" viewBox="0 0 30 30" fill="none"
-            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2">
+            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="11" cy="11" r="8" />
             <path d="M21 21L16.65 16.65" />
         </svg></button>
-    <button class="search-button" onclick="read()">
-        <svg width="30" height="30" viewBox="0 0 30 30" fill="none" 
-            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2">
+    <button class="search-button" onclick="read()" aria-label="Read aloud">
+        <svg width="30" height="30" viewBox="0 0 30 30" fill="none"
+            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
             <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
             <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
         </svg></button>
-    <button class="search-button" onclick="pasteAndSearch()">
-        <svg width="30" height="30" viewBox="0 0 30 30" fill="none" 
-            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2">
+    <button class="search-button" onclick="pasteAndSearch()" aria-label="Paste and search">
+        <svg width="30" height="30" viewBox="0 0 30 30" fill="none"
+            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
         </svg>
@@ -251,3 +255,5 @@
         }
     });
 </script>
+</body>
+</html>

--- a/src/LunaTranslator/htmlcode/service/translate.html
+++ b/src/LunaTranslator/htmlcode/service/translate.html
@@ -1,6 +1,10 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
 <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+    <meta charset="UTF-8">
+    <title>LunaTranslator</title>
 </head>
+<body>
 <script>
     function onclickbtn_1_internal(_id) {
         tabPanes = document.querySelectorAll('.tab-widget_1_internal .tab-pane_1_internal');
@@ -101,16 +105,16 @@
     }
 </script>
 <div class="search-container">
-    <textarea class="search-input" id="searchInput"></textarea>
+    <textarea class="search-input" id="searchInput" aria-label="Text to translate"></textarea>
     <div>
-        <button class="search-button" onclick="performSearch()"><svg width="24" height="24" viewBox="0 0 24 24"
-                fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2">
+        <button class="search-button" onclick="performSearch()" aria-label="Search"><svg width="24" height="24" viewBox="0 0 24 24"
+                fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <circle cx="11" cy="11" r="8" />
                 <path d="M21 21L16.65 16.65" />
             </svg></button>
-        <button class="search-button" onclick="read()"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+        <button class="search-button" onclick="read()" aria-label="Read aloud"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                stroke-linejoin="round">
+                stroke-linejoin="round" aria-hidden="true">
                 <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
                 <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
                 <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
@@ -180,8 +184,8 @@
         if (!text) return
         let tss = await gettranslators()
         tss.forEach(element => {
-            let html = `<div><div class="collapsible-header flex-parent " id="tsid_${element.id}"><div class="align-left">${element.name}</div><button class="align-right" onclick="researchx('${element.id}')" id="btnid_${element.id}"><svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2">
+            let html = `<div><div class="collapsible-header flex-parent " id="tsid_${element.id}"><div class="align-left">${element.name}</div><button class="align-right" onclick="researchx('${element.id}')" id="btnid_${element.id}" aria-label="Translate again"><svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+            xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="11" cy="11" r="8" />
             <path d="M21 21L16.65 16.65" />
         </svg></button></div><div class="collapsible-content" style="display: none;" id="tsresid_${element.id}"></div></div>`
@@ -213,3 +217,5 @@
     translateall(word)
     document.getElementById('searchInput').value = word
 </script>
+</body>
+</html>

--- a/src/LunaTranslator/htmlcode/service/translate.html
+++ b/src/LunaTranslator/htmlcode/service/translate.html
@@ -184,7 +184,7 @@
         if (!text) return
         let tss = await gettranslators()
         tss.forEach(element => {
-            let html = `<div><div class="collapsible-header flex-parent " id="tsid_${element.id}"><div class="align-left">${element.name}</div><button class="align-right" onclick="researchx('${element.id}')" id="btnid_${element.id}" aria-label="Translate again"><svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+            let html = `<div><div class="collapsible-header flex-parent " id="tsid_${element.id}"><div class="align-left">${element.name}</div><button class="align-right" onclick="researchx('${element.id}')" id="btnid_${element.id}" aria-label="Translate again for ${element.name}"><svg width="24" height="24" viewBox="0 0 24 24" fill="none"
             xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="11" cy="11" r="8" />
             <path d="M21 21L16.65 16.65" />

--- a/src/LunaTranslator/htmlcode/service/tts.html
+++ b/src/LunaTranslator/htmlcode/service/tts.html
@@ -1,6 +1,10 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
 <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+    <meta charset="UTF-8">
+    <title>LunaTranslator</title>
 </head>
+<body>
 <style>
     .search-input {
         padding: 10px 15px;
@@ -44,9 +48,9 @@
     }
 </script>
 <div height="24px" style="display: flex;">
-    <button class="search-button" onclick="performSearch()"><svg version="1.1" width="24" height="24" id="Capa_1"
+    <button class="search-button" onclick="performSearch()" aria-label="Download audio"><svg version="1.1" width="24" height="24" id="Capa_1"
             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 29.978 29.978"
-            xml:space="preserve">
+            xml:space="preserve" aria-hidden="true">
             <style>
                 path {
                     fill: white;
@@ -58,12 +62,14 @@
                 <path
                     d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z" />
         </svg></button>
-    <button class="search-button" onclick="read()"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+    <button class="search-button" onclick="read()" aria-label="Play audio"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
             viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round">
+            stroke-linejoin="round" aria-hidden="true">
             <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
             <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
             <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
         </svg></button>
 </div>
-<textarea class="search-input" id="searchInput" style="height: calc( 100% - 48px );"></textarea>
+<textarea class="search-input" id="searchInput" style="height: calc( 100% - 48px );" aria-label="Text to read aloud"></textarea>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic HTML document structure to dictionary, translate, and TTS service pages
- add accessible names to unlabeled inputs, textareas, and icon-only buttons
- hide decorative inline SVGs from assistive technologies
- give dynamically generated translate retry buttons unique accessible labels per translator

## Testing
- git diff --check
- rg -n "Translate again for" src/LunaTranslator/htmlcode/service/translate.html
- CodeRabbit review on skarL007/LunaTranslator#7: no actionable comments
