### PR TITLE
fix: pass missing apitype argument in LLM TTS

### DIFF
--- a/src/LunaTranslator/tts/chatgpttts.py
+++ b/src/LunaTranslator/tts/chatgpttts.py
@@ -48,7 +48,9 @@ class TTS(TTSbase):
                 apitype, content, voice, speed, extrabody, extraheader
             )
         else:
-            return self.requestnormal(content, voice, speed, extrabody, extraheader)
+            return self.requestnormal(
+                apitype, content, voice, speed, extrabody, extraheader
+            )
 
     def requestnormal(
         self, apitype: APIType, content, voice, speed, extrabody, extraheader


### PR DESCRIPTION
The "General LLM Interface" option in Text-to-Speech would silently fail to generate audio due to a missing `apitype` parameter.
This appears to be commit 4207cff88's fault, where the Gemini path was updated but the "normal" path wasn't.