### PR TITLE
ci: Fixes missing toolchain for XP

### DIFF
--- a/.github/workflows/buildluna.yml
+++ b/.github/workflows/buildluna.yml
@@ -9,12 +9,13 @@ on:
     #     required: false 
 jobs:
   buildall:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os || 'windows-latest' }} 
     strategy:
       matrix:
         include:  
           - arch: x86
             target: winxp
+            os: windows-2022
           - arch: x86
             target: win7
             pythonversion: '3.7.9' 
@@ -30,7 +31,7 @@ jobs:
       - if: matrix.target == 'winxp'
         run: |
             $vs_installer = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe"
-            $InstallPath = "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
+            $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
             $componentsToAdd = @(
               "Microsoft.VisualStudio.Component.WinXP"
             )

--- a/src/scripts/build_lunatranslator.py
+++ b/src/scripts/build_lunatranslator.py
@@ -219,7 +219,7 @@ def buildhook(arch, target, hookonly=False):
 
     os.chdir("NativeImpl/LunaHook")
     archA = ("win32", "x64")[arch == "x64"]
-    vsver = "Visual Studio 18 2026"
+    vsver = "Visual Studio 17 2022" if target == "winxp" else "Visual Studio 18 2026"
     Tool = "v141_xp" if target == "winxp" else f"host={arch}"
     if target == "win10":
         config = "-DWIN10ABOVE=ON"
@@ -255,7 +255,7 @@ def buildPlugins(arch, target, configx="", sexe=False):
     elif target == "winxp":
         config = "-DWINXP=ON -DWIN10ABOVE=OFF"
     sysver = " -DCMAKE_SYSTEM_VERSION=10.0.26621.0 "
-    vsver = "Visual Studio 18 2026"
+    vsver = "Visual Studio 17 2022" if target == "winxp" else "Visual Studio 18 2026"
     Tool = "v141_xp" if target == "winxp" else f"host={arch}"
 
     if arch == "x86" and target == "win10":


### PR DESCRIPTION
The latest version of Visual Studio has finally dropped the Windows XP support component, causing the workflow to no longer work. This updates the build workflow for Windows XP to use an older image that contains VS 2022 which still has the required  XP component.

A successful build execution can be seen here:
https://github.com/fadillzzz/LunaTranslator/actions/runs/30882192315/job/91905717986