### PR TITLE
内嵌翻译选择清除内嵌文本时，改为嵌入半角+全角空格

### DIFF
--- a/src/NativeImpl/LunaHook/LunaHook/embed_util.cc
+++ b/src/NativeImpl/LunaHook/LunaHook/embed_util.cc
@@ -275,7 +275,7 @@ bool TextHook::waitfornotify(TextBuffer *buff, ThreadParam tp)
 {
   if (commonsharedmem->clearText)
   {
-    buff->from(" "); // 也可以选择对齐空格长度。到底哪个更稳定需要更多测试
+    buff->from(" 　"); // 也可以选择对齐空格长度。到底哪个更稳定需要更多测试
     return true;
   }
   std::wstring origin;


### PR DESCRIPTION
原逻辑是嵌入单个半角空格，在aokona(steam edition)中会导致跳过对话。此修改能解决这个问题。