### PR TITLE
Settings UI: cleaner engine sections and aligned controls (OCR / TTS / dictionaries)

### DIFF
--- a/src/LunaTranslator/defaultconfig/config.json
+++ b/src/LunaTranslator/defaultconfig/config.json
@@ -887,7 +887,8 @@
         },
         "selfbuild": {
             "use": false,
-            "name": "自定义"
+            "name": "自定义",
+            "type": "other"
         },
         "voiceroid2": {
             "use": false,
@@ -1317,7 +1318,8 @@
         },
         "selfbuild": {
             "use": false,
-            "name": "自定义"
+            "name": "自定义",
+            "type": "other"
         }
     },
     "useopenlinklink1": [

--- a/src/LunaTranslator/gui/setting/cishu.py
+++ b/src/LunaTranslator/gui/setting/cishu.py
@@ -7,13 +7,14 @@ from myutils.wrapper import Singleton
 from gui.inputdialog import autoinitdialog_items, autoinitdialog
 from gui.rcdownload import resourcewidget, resourcewidget2
 from gui.usefulwidget import (
+    getlabelminwidth,
     LGroupBox,
     VisLFormLayout,
     makescrollgrid,
     D_getsimpleswitch,
     listediter,
     D_getIconButton,
-    LPushButton,
+    IconButton,
     NQGroupBox,
     getsmalllabel,
     D_getdoclink,
@@ -140,6 +141,7 @@ def getrenameablellabel(uid, self):
     name = ClickableLabel(dynamiccishuname(uid))
     fn = functools.partial(renameapi, name, uid, self)
     name.clicked.connect(fn)
+    name.setMinimumWidth(getlabelminwidth("Youdao Dictionary"))
     return name
 
 
@@ -236,13 +238,16 @@ def fenciqisettings(self):
         ),
     )
     l1.addWidget(_3())
-    l1.addStretch(1)
-    btn = LPushButton("资源下载")
-    btn.setCheckable(True)
+    btn = IconButton(
+        icon="fa.download",
+        checkable=True,
+        checkablechangecolor=False,
+        tips="资源下载",
+    )
     reflist = []
     btn.clicked.connect(functools.partial(clickcallback, reflist, lay))
     l1.addWidget(btn)
-    l1.addStretch(8)
+    l1.addStretch(1)
     return box
 
 
@@ -271,13 +276,16 @@ def mdictsettings(self):
         ),
     )
     l1.addWidget(_3())
-    l1.addStretch(1)
-    btn = LPushButton("资源下载")
-    btn.setCheckable(True)
+    btn = IconButton(
+        icon="fa.download",
+        checkable=True,
+        checkablechangecolor=False,
+        tips="资源下载",
+    )
     reflist = []
     btn.clicked.connect(functools.partial(clickcallback2, reflist, lay))
     l1.addWidget(btn)
-    l1.addStretch(8)
+    l1.addStretch(1)
     return box
 
 
@@ -362,7 +370,7 @@ class fontsettings(NQGroupBox):
 def setTabcishu_l(self):
 
     grids_1 = [functools.partial(fenciqisettings, self)]
-    _, online = splitocrtypes(globalconfig["cishu"])
+    _, online, other = splitocrtypes(globalconfig["cishu"], other=True)
     cishu = dict(
         title="辞书",
         button=D_getdoclink("internaldict.html"),
@@ -374,6 +382,13 @@ def setTabcishu_l(self):
                     title="在线",
                     type="grid",
                     grid=initinternal(self, online),
+                )
+            ],
+            [
+                dict(
+                    title="其他",
+                    type="grid",
+                    grid=initinternal(self, other),
                 )
             ],
         ],
@@ -643,7 +658,6 @@ def setTabcishu_l(self):
     grids = [
         grids_1,
         [cishu],
-        [],
         [zhuyin],
         [fenci],
     ]

--- a/src/LunaTranslator/gui/setting/textinput_ocr.py
+++ b/src/LunaTranslator/gui/setting/textinput_ocr.py
@@ -4,6 +4,7 @@ from myutils.config import globalconfig, ocrsetting, ocrerrorfix
 from myutils.utils import splitocrtypes, getimagefilefilter, selectdebugfile
 from gui.inputdialog import postconfigdialog, autoinitdialog_items, autoinitdialog
 from gui.usefulwidget import (
+    getlabelminwidth,
     D_getsimplecombobox,
     D_getspinbox,
     D_getIconButton,
@@ -14,7 +15,6 @@ from gui.usefulwidget import (
     D_getdoclink,
     ClickableLabel,
     getboxlayout,
-    createfoldgrid,
     TableViewW,
     saveposwindow,
     check_grid_append,
@@ -163,11 +163,13 @@ def renameapi(qlabel: QLabel, apiuid):
 
 def getrenameablellabel(uid):
     if globalconfig["ocr"][uid].get("type") in ("offline",):
-        return LLabel(globalconfig["ocr"][uid]["name"])
-    name = ClickableLabel(globalconfig["ocr"][uid]["name"])
-    fn = functools.partial(renameapi, name, uid)
-    name.clicked.connect(fn)
-    name.beforeEnter.connect(functools.partial(checkclickable, name))
+        name = LLabel(globalconfig["ocr"][uid]["name"])
+    else:
+        name = ClickableLabel(globalconfig["ocr"][uid]["name"])
+        fn = functools.partial(renameapi, name, uid)
+        name.clicked.connect(fn)
+        name.beforeEnter.connect(functools.partial(checkclickable, name))
+    name.setMinimumWidth(getlabelminwidth("googlecloudvision"))
     return name
 
 
@@ -463,37 +465,38 @@ def internal(self):
             )
         ],
         [
-            (
-                functools.partial(
-                    createfoldgrid,
-                    [
-                        [
-                            dict(
-                                type="grid",
-                                title="其他",
-                                grid=initgridsources(self, other),
-                            )
-                        ],
-                        [
-                            dict(
-                                type="grid",
-                                title="过时的",
-                                grid=initgridsources(self, outdate),
-                            )
-                        ],
-                    ],
-                    "其他",
-                    d=globalconfig["foldstatus"]["ocr"],
-                    k="other",
-                ),
-                -1,
+            dict(
+                type="grid",
+                title="其他",
+                grid=initgridsources(self, other),
             )
         ],
         [
-            D_getIconButton(
-                callback=lambda: showocrimage(self), icon="fa.picture-o", tips="查看"
-            ),
-            "",
+            dict(
+                type="grid",
+                title="过时的",
+                grid=initgridsources(self, outdate),
+            )
+        ],
+        [
+            dict(
+                title="测试",
+                type="grid",
+                grid=[
+                    [
+                        getboxlayout(
+                            [
+                                D_getIconButton(
+                                    callback=lambda: showocrimage(self),
+                                    icon="fa.picture-o",
+                                    tips="测试",
+                                ),
+                                1,
+                            ]
+                        )
+                    ]
+                ],
+            )
         ],
     ]
     autorun = [

--- a/src/LunaTranslator/gui/setting/tts.py
+++ b/src/LunaTranslator/gui/setting/tts.py
@@ -13,6 +13,7 @@ from gui.dynalang import LAction, LLabel
 from tts.basettsclass import TTSbase
 from gui.setting.about import offlinelinks
 from gui.usefulwidget import (
+    getlabelminwidth,
     D_getspinbox,
     D_getdoclink,
     makescrollgrid,
@@ -122,11 +123,13 @@ def checkclickable(name: ClickableLabel):
 
 def getrenameablellabel(uid):
     if globalconfig["reader"][uid].get("type") in ("offline",):
-        return LLabel(globalconfig["reader"][uid]["name"])
-    name = ClickableLabel(globalconfig["reader"][uid]["name"])
-    fn = functools.partial(renameapi, name, uid)
-    name.beforeEnter.connect(functools.partial(checkclickable, name))
-    name.clicked.connect(fn)
+        name = LLabel(globalconfig["reader"][uid]["name"])
+    else:
+        name = ClickableLabel(globalconfig["reader"][uid]["name"])
+        fn = functools.partial(renameapi, name, uid)
+        name.beforeEnter.connect(functools.partial(checkclickable, name))
+        name.clicked.connect(fn)
+    name.setMinimumWidth(getlabelminwidth("Volcengine TTS"))
     return name
 
 
@@ -195,13 +198,15 @@ def getttsgrid(self, names):
         i += 1
     if len(line):
         grids.append(line)
+    if grids:
+        grids[-1] += [""] * (11 - len(grids[-1]))
     check_grid_append(grids)
     return grids
 
 
 def setTab5lz(self):
     grids = []
-    offline, online = splitocrtypes(globalconfig["reader"])
+    offline, online, other = splitocrtypes(globalconfig["reader"], other=True)
     offilesgrid = getttsgrid(self, offline)
     offilesgrid += [
         [(functools.partial(offlinelinks, "tts"), 0)],
@@ -214,6 +219,7 @@ def setTab5lz(self):
                 grid=[
                     [dict(title="离线", type="grid", grid=offilesgrid)],
                     [dict(title="在线", type="grid", grid=getttsgrid(self, online))],
+                    [dict(title="其他", type="grid", grid=getttsgrid(self, other))],
                 ],
             ),
         ],

--- a/src/LunaTranslator/gui/usefulwidget.py
+++ b/src/LunaTranslator/gui/usefulwidget.py
@@ -1320,6 +1320,10 @@ def check_grid_append(grids: "list[list]", minlen=None):
     return notx
 
 
+def getlabelminwidth(reference: str, padding: int = 20) -> int:
+    return int(QFontMetricsF(QApplication.font()).horizontalAdvance(reference)) + padding
+
+
 def D_getcolorbutton(parent, d, key, callback, alpha=False, tips="颜色", default=None):
     return lambda: ColorButton(
         parent, d, key, callback, alpha=alpha, tips=tips, default=default


### PR DESCRIPTION
## Summary

Layout-only cleanup of the engine lists in Settings. No functional changes.

- **OCR engines**: the "Other" and "Outdated" groups are rendered as flat sections like Offline/Online, instead of a collapsible fold. The image test action got its own titled section instead of a bare unlabeled icon
- **TTS / dictionaries**: the custom (`selfbuild`) engine moved from "Online" into its own "Other" section — `"type": "other"` in `defaultconfig/config.json` (`syncconfig` applies this key to existing user configs automatically)
- **OCR / TTS / dictionaries**: engine name labels get a uniform minimum width computed from the current font plus padding (no hardcoded pixels, follows DPI and font settings), so name/toggle/button columns line up across all engine sections. The trailing partial row of the TTS grid is padded with empty cells so existing columns don't stretch
- **Dictionaries**: removed an empty spacer row between sections; the wide "Download resources" buttons (MeCab, MDict) replaced with compact icon toggles

## Testing

Verified in the packaged app (v10.16.5.3) — Settings → Dictionaries / OCR engines / TTS. All touched files compile, JSON validated, CRLF line endings preserved.

Before/after screenshots are attached in the comments below.
